### PR TITLE
Handle missing dates in changelog entries

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -215,8 +215,13 @@ security_json = {}
 
 # Iterate over each version
 for version in soup.find_all("h2"):
-    version_number = version.get_text().strip().split(" - ")[0][1:-1]  # Remove brackets
-    date = version.get_text().strip().split(" - ")[1]
+    version_text = version.get_text().strip()
+    parts = version_text.split(" - ", 1)
+    if len(parts) < 2:
+        log.warning(f"Skipping changelog entry with missing date: {version_text}")
+        continue
+    version_number = parts[0][1:-1]  # Remove brackets
+    date = parts[1]
 
     version_data = {"date": date}
 


### PR DESCRIPTION
## Summary
- avoid IndexError when parsing changelog versions without dates by verifying split results and logging a warning

## Testing
- `python -m py_compile backend/open_webui/env.py`
- `pytest backend/open_webui/test` *(fails: /workspace/scout/pyproject.toml: Unclosed array (at line 36, column 5))*

------
https://chatgpt.com/codex/tasks/task_e_688e6d34d020832f9ab8abc9de19f8ba