### PR TITLE
fix: fallback to CPU on CUDA errors

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -124,7 +124,18 @@ def set_faster_whisper_model(model: str, auto_update: bool = False):
                 "WhisperModel initialization failed, attempting download with local_files_only=False"
             )
             faster_whisper_kwargs["local_files_only"] = False
-            whisper_model = WhisperModel(**faster_whisper_kwargs)
+            try:
+                whisper_model = WhisperModel(**faster_whisper_kwargs)
+            except Exception as e:
+                error_message = str(e).lower()
+                if "cudnn" in error_message or "libcudnn" in error_message:
+                    log.warning(
+                        "CUDA-related error detected (%s); falling back to CPU", e
+                    )
+                    faster_whisper_kwargs["device"] = "cpu"
+                    whisper_model = WhisperModel(**faster_whisper_kwargs)
+                else:
+                    raise
     return whisper_model
 
 


### PR DESCRIPTION
## Summary
- handle CUDA-related failures in WhisperModel initialization
- retry with `local_files_only=False` and fall back to CPU when CUDA libraries are missing

## Testing
- `pytest` *(fails: /workspace/scout/pyproject.toml: Unclosed array (at line 36, column 5))*

------
https://chatgpt.com/codex/tasks/task_e_688e764e051c832f8bf95c16d828946c