### PR TITLE
Preload local Whisper model at startup

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -29,6 +29,7 @@ from open_webui.env import (
     REDIS_SENTINEL_HOSTS,
     REDIS_SENTINEL_PORT,
     FRONTEND_BUILD_DIR,
+    WHISPER_MODEL_DIR,
     OFFLINE_MODE,
     OPEN_WEBUI_DIR,
     WEBUI_AUTH,
@@ -2422,7 +2423,6 @@ WHISPER_MODEL = PersistentConfig(
     os.getenv("WHISPER_MODEL", "base"),
 )
 
-WHISPER_MODEL_DIR = os.getenv("WHISPER_MODEL_DIR", f"{CACHE_DIR}/whisper/models")
 WHISPER_MODEL_AUTO_UPDATE = (
     not OFFLINE_MODE
     and os.environ.get("WHISPER_MODEL_AUTO_UPDATE", "").lower() == "true"

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -328,6 +328,15 @@ if FROM_INIT_PY:
     ).resolve()
 
 ####################################
+# Whisper model directory
+####################################
+
+WHISPER_MODEL_DIR = Path(
+    os.getenv("WHISPER_MODEL_DIR", DATA_DIR / "cache" / "whisper" / "models")
+).resolve()
+WHISPER_MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+####################################
 # Database
 ####################################
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -776,6 +776,29 @@ app.state.config.STT_MODEL = AUDIO_STT_MODEL
 
 app.state.config.WHISPER_MODEL = WHISPER_MODEL
 app.state.config.DEEPGRAM_API_KEY = DEEPGRAM_API_KEY
+app.state.config.WHISPER_MODEL_DIR = WHISPER_MODEL_DIR
+
+if app.state.config.STT_ENGINE == "":
+    logger.info(
+        f"Preloading Whisper model '{WHISPER_MODEL}' into {WHISPER_MODEL_DIR}"
+    )
+    try:
+        app.state.faster_whisper_model = audio.set_faster_whisper_model(
+            WHISPER_MODEL, auto_update=WHISPER_MODEL_AUTO_UPDATE
+        )
+        device = getattr(app.state.faster_whisper_model, "device", "cpu")
+        if device == "cpu":
+            logger.warning(
+                "Whisper model loaded on CPU; performance may be degraded"
+            )
+        else:
+            logger.info(f"Whisper model loaded on {device}")
+    except Exception as e:
+        logger.warning(
+            f"Failed to preload Whisper model '{WHISPER_MODEL}': {e}"
+        )
+else:
+    app.state.faster_whisper_model = None
 
 app.state.config.TTS_OPENAI_API_BASE_URL = AUDIO_TTS_OPENAI_API_BASE_URL
 app.state.config.TTS_OPENAI_API_KEY = AUDIO_TTS_OPENAI_API_KEY
@@ -790,7 +813,6 @@ app.state.config.TTS_AZURE_SPEECH_REGION = AUDIO_TTS_AZURE_SPEECH_REGION
 app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT = AUDIO_TTS_AZURE_SPEECH_OUTPUT_FORMAT
 
 
-app.state.faster_whisper_model = None
 app.state.speech_synthesiser = None
 app.state.speech_speaker_embeddings_dataset = None
 


### PR DESCRIPTION
## Summary
- Preload faster-whisper model during startup when STT engine is local
- Store model in `app.state.faster_whisper_model` and log device used
- Configure download path to use `WHISPER_MODEL_DIR`

## Testing
- `python -m black backend/open_webui/main.py` *(fails: Could not open file 'pyproject.toml')*
- `pytest` *(fails: Unclosed array in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_688e78e7b2c8832f87a1fa4582a8f89c