### PR TITLE
refactor: simplify faster whisper device selection

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -136,7 +136,7 @@ def set_faster_whisper_model(
             else (
                 "cpu"
                 if force_cpu
-                else (DEVICE_TYPE if DEVICE_TYPE and DEVICE_TYPE == "cuda" else "cpu")
+                else (DEVICE_TYPE if DEVICE_TYPE == "cuda" else "cpu")
             ),
             "compute_type": "int8",
             "download_root": WHISPER_MODEL_DIR,


### PR DESCRIPTION
## Summary
- remove redundant `DEVICE_TYPE` check when selecting faster-whisper device

## Testing
- `python -m py_compile backend/open_webui/routers/audio.py`
- `pytest -c /dev/null` *(fails: ModuleNotFoundError: No module named 'test.util'; ModuleNotFoundError: No module named 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_688e962ea720832fa0e90f69812e3bba