### PR TITLE
fix: clean typography overrides

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,17 +23,17 @@ export default {
 					950: 'var(--color-gray-950, #0d0d0d)'
 				}
 			},
-			typography: {
-				DEFAULT: {
-					css: {
-						pre: false,
-						code: false,
-						'pre code': false,
-						'code::before': false,
-						'code::after': false
-					}
-				}
-			},
+                        typography: {
+                                DEFAULT: {
+                                        css: {
+                                                pre: null,
+                                                code: null,
+                                                'pre code': null,
+                                                'code::before': { content: 'none' },
+                                                'code::after': { content: 'none' }
+                                        }
+                                }
+                        },
 			padding: {
 				'safe-bottom': 'env(safe-area-inset-bottom)'
 			}


### PR DESCRIPTION
## Summary
- remove `false` typography overrides in Tailwind config
- explicitly disable code pseudo-element content

## Testing
- `node --input-type=module -e "import fs from 'fs'; import postcss from 'postcss'; import tailwindcss from '@tailwindcss/postcss'; import config from './tailwind.config.js'; const css=fs.readFileSync('src/app.css','utf8'); postcss([tailwindcss({config})]).process(css,{from:'src/app.css'}).then(r=>{fs.writeFileSync('/tmp/output.css', r.css); console.log('done');}).catch(e=>{console.error(e);})" >/tmp/tw.log && tail -n 20 /tmp/tw.log`
- `grep -n "code:false" /tmp/output.css || echo 'no code:false'`
- `grep -n "pre:false" /tmp/output.css || echo 'no pre:false'`
- `npm run build` *(fails: ModuleNotFoundError: No module named 'micropip')*

------
https://chatgpt.com/codex/tasks/task_e_688ecfabd72c832fb9ca5bda50674d8f