### PR TITLE
chore: mark camera feed video as decorative

### DIFF
--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -850,12 +850,13 @@
 				</button>
 			{:else}
 				<div class="relative flex video-container w-full max-h-full pt-2 pb-4 md:py-6 px-2 h-full">
-					<video
-						id="camera-feed"
-						autoplay
-						class="rounded-2xl h-full min-w-full object-cover object-center"
-						playsinline
-					/>
+                                       <video
+                                               id="camera-feed"
+                                               autoplay
+                                               class="rounded-2xl h-full min-w-full object-cover object-center"
+                                               playsinline
+                                               aria-hidden="true"
+                                       />
 
 					<canvas id="camera-canvas" style="display:none;" />
 


### PR DESCRIPTION
## Summary
- mark CallOverlay camera feed video as aria-hidden to avoid accessibility warning

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find package 'pyodide')*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed72341e8832f8dcf82fbbf322569