### PR TITLE
fix: replace placeholder anchor in file item modal

### DIFF
--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -33,22 +33,22 @@
 		<div class=" pb-2">
 			<div class="flex items-start justify-between">
 				<div>
-					<div class=" font-medium text-lg dark:text-gray-100">
-						<a
-							href="#"
-							class="hover:underline line-clamp-1"
-							on:click|preventDefault={() => {
-								if (!isPDF && item.url) {
-									window.open(
-										item.type === 'file' ? `${item.url}/content` : `${item.url}`,
-										'_blank'
-									);
-								}
-							}}
-						>
-							{item?.name ?? 'File'}
-						</a>
-					</div>
+                                        <div class=" font-medium text-lg dark:text-gray-100">
+                                                <button
+                                                        type="button"
+                                                        class="hover:underline line-clamp-1 bg-transparent p-0 text-left"
+                                                        on:click={() => {
+                                                                if (!isPDF && item.url) {
+                                                                        window.open(
+                                                                                item.type === 'file' ? `${item.url}/content` : `${item.url}`,
+                                                                                '_blank'
+                                                                        );
+                                                                }
+                                                        }}
+                                                >
+                                                        {item?.name ?? 'File'}
+                                                </button>
+                                        </div>
 				</div>
 
 				<div>


### PR DESCRIPTION
## Summary
- replace non-navigating anchor with button styled as a link in FileItemModal for better accessibility

## Testing
- `npx eslint src/lib/components/common/FileItemModal.svelte`
- `npm run test:frontend` *(fails: No test files found)*
- `npm run lint:frontend` *(fails: 950 errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_688ed976bf34832f9ecbd1e7e54c9917