### PR TITLE
chore: upgrade svelte for untrack support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "3.2.2",
 		"@sveltejs/adapter-static": "^3.0.2",
-		"@sveltejs/kit": "^2.20.6",
+               "@sveltejs/kit": "^2.26.1",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@tailwindcss/container-queries": "^0.1.1",
 		"@tailwindcss/postcss": "^4.0.0",
@@ -44,7 +44,7 @@
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.2.6",
 		"sass-embedded": "^1.81.0",
-		"svelte": "^4.2.18",
+               "svelte": "^5.0.0-next.0",
 		"svelte-check": "^3.8.5",
 		"svelte-confetti": "^1.3.2",
 		"tailwindcss": "^4.0.0",


### PR DESCRIPTION
## Summary
- bump `svelte` to a release line that exports `untrack`
- update SvelteKit to a compatible version

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/svelte)*
- `npm run build` *(fails: Cannot find package 'pyodide' imported from scripts/prepare-pyodide.js)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688edc591c2c832f9ad150aec9ea84e8