### PR TITLE
chore: remove unused svelte props

### DIFF
--- a/src/lib/components/admin/Settings/Models/ModelMenu.svelte
+++ b/src/lib/components/admin/Settings/Models/ModelMenu.svelte
@@ -18,13 +18,12 @@
 
 	const i18n = getContext('i18n');
 
-	export let user;
-	export let model;
+        export let model;
 
-	export let exportHandler: Function;
-	export let hideHandler: Function;
+        export let exportHandler: Function;
+        export let hideHandler: Function;
 
-	export let onClose: Function;
+        export let onClose: Function;
 
 	let show = false;
 </script>

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -20,10 +20,9 @@
 	import { transcribeAudio } from '$lib/apis/audio';
 	import FilesOverlay from '../chat/MessageInput/FilesOverlay.svelte';
 
-	export let placeholder = $i18n.t('Send a Message');
-	export let transparentBackground = false;
-
-	export let id = null;
+        export let placeholder = $i18n.t('Send a Message');
+        
+        export let id = null;
 
 	let draggedOver = false;
 

--- a/src/lib/components/channel/Messages/Message/ReactionPicker.svelte
+++ b/src/lib/components/channel/Messages/Message/ReactionPicker.svelte
@@ -6,11 +6,10 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import VirtualList from '@sveltejs/svelte-virtual-list';
 
-	export let onClose = () => {};
-	export let onSubmit = (name) => {};
-	export let side = 'top';
-	export let align = 'start';
-	export let user = null;
+        export let onClose = () => {};
+        export let onSubmit = (name) => {};
+        export let side = 'top';
+        export let align = 'start';
 
 	let show = false;
 	let emojis = emojiShortCodes;

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -10,9 +10,8 @@
 	import Collapsible from '$lib/components/common/Collapsible.svelte';
 
 	import { user } from '$lib/stores';
-	export let models = [];
-	export let chatFiles = [];
-	export let params = {};
+        export let chatFiles = [];
+        export let params = {};
 
 	let showValves = false;
 </script>

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -117,7 +117,6 @@
 	export let updateChat: Function;
 	export let editMessage: Function;
 	export let saveMessage: Function;
-	export let rateMessage: Function;
 	export let actionMessage: Function;
 	export let deleteMessage: Function;
 

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -29,9 +29,8 @@
 
 	const i18n = getContext('i18n');
 
-	export let initNewChat: Function;
-	export let title: string = $WEBUI_NAME;
-	export let shareEnabled: boolean = false;
+        export let initNewChat: Function;
+        export let shareEnabled: boolean = false;
 
 	export let chat;
 	export let selectedModels;

--- a/src/lib/components/chat/Settings/Chats.svelte
+++ b/src/lib/components/chat/Settings/Chats.svelte
@@ -19,7 +19,6 @@
 
 	const i18n = getContext('i18n');
 
-	export let saveSettings: Function;
 
 	// Chats
 	let importFiles;

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -11,8 +11,7 @@
 	import AdvancedParams from './Advanced/AdvancedParams.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
 
-	export let saveSettings: Function;
-	export let getModels: Function;
+        export let saveSettings: Function;
 
 	// General
 	let themes = ['dark', 'light', 'rose-pine dark', 'rose-pine-dawn light', 'oled-dark'];

--- a/src/lib/components/common/Folder.svelte
+++ b/src/lib/components/common/Folder.svelte
@@ -10,10 +10,9 @@
 	import Tooltip from './Tooltip.svelte';
 	import Plus from '../icons/Plus.svelte';
 
-	export let open = true;
+        export let open = true;
 
-	export let id = '';
-	export let name = '';
+        export let name = '';
 	export let collapsible = true;
 
 	export let onAddLabel: string = '';

--- a/src/lib/components/icons/ChartBar.svelte
+++ b/src/lib/components/icons/ChartBar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	export let className = 'size-4';
-	export let strokeWidth = '1.5';
+        export let className = 'size-4';
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class={className}>

--- a/src/lib/components/icons/Cog6Solid.svelte
+++ b/src/lib/components/icons/Cog6Solid.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	export let className = 'w-4 h-4';
-	export let strokeWidth = '1.5';
+        export let className = 'w-4 h-4';
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class={className}>

--- a/src/lib/components/icons/DocumentChartBar.svelte
+++ b/src/lib/components/icons/DocumentChartBar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	export let className = 'size-4';
-	export let strokeWidth = '1.5';
+        export let className = 'size-4';
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class={className}>

--- a/src/lib/components/icons/PencilSolid.svelte
+++ b/src/lib/components/icons/PencilSolid.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	export let className = 'w-4 h-4';
-	export let strokeWidth = '1.5';
+        export let className = 'w-4 h-4';
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class={className}>

--- a/src/lib/components/icons/SparklesSolid.svelte
+++ b/src/lib/components/icons/SparklesSolid.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	export let className = 'w-4 h-4';
-	export let strokeWidth = '1.5';
+        export let className = 'w-4 h-4';
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class={className}>

--- a/src/lib/components/layout/Help/HelpMenu.svelte
+++ b/src/lib/components/layout/Help/HelpMenu.svelte
@@ -11,10 +11,9 @@
 	import Keyboard from '$lib/components/icons/Keyboard.svelte';
 	const i18n = getContext('i18n');
 
-	export let showDocsHandler: Function;
-	export let showShortcutsHandler: Function;
+        export let showShortcutsHandler: Function;
 
-	export let onClose: Function = () => {};
+        export let onClose: Function = () => {};
 </script>
 
 <Dropdown

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -30,9 +30,8 @@
 
 	const i18n = getContext('i18n');
 
-	export let initNewChat: Function;
-	export let title: string = $WEBUI_NAME;
-	export let shareEnabled: boolean = false;
+        export let initNewChat: Function;
+        export let shareEnabled: boolean = false;
 
 	export let chat;
 	export let selectedModels;

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -32,14 +32,12 @@
 
 	const i18n = getContext('i18n');
 
-	export let shareEnabled: boolean = false;
-	export let shareHandler: Function;
-	export let downloadHandler: Function;
+        export let shareHandler: Function;
 
-	// export let tagHandler: Function;
+        // export let tagHandler: Function;
 
-	export let chat;
-	export let onClose: Function = () => {};
+        export let chat;
+        export let onClose: Function = () => {};
 
 	const getChatAsText = async () => {
 		const history = chat.chat.history;

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -3,8 +3,7 @@
 	import Selector from './Knowledge/Selector.svelte';
 	import FileItem from '$lib/components/common/FileItem.svelte';
 
-	export let selectedKnowledge = [];
-	export let collections = [];
+        export let selectedKnowledge = [];
 
 	const i18n = getContext('i18n');
 </script>

--- a/src/lib/components/workspace/Models/ModelMenu.svelte
+++ b/src/lib/components/workspace/Models/ModelMenu.svelte
@@ -18,16 +18,11 @@
 
 	const i18n = getContext('i18n');
 
-	export let user;
-	export let model;
-
-	export let shareHandler: Function;
-	export let cloneHandler: Function;
-	export let exportHandler: Function;
-
-	export let hideHandler: Function;
-	export let deleteHandler: Function;
-	export let onClose: Function;
+        export let shareHandler: Function;
+        export let cloneHandler: Function;
+        export let exportHandler: Function;
+        export let deleteHandler: Function;
+        export let onClose: Function;
 
 	let show = false;
 </script>


### PR DESCRIPTION
## Summary
- remove unused export variables from chat and layout navbars
- drop unused props from various components such as message input and menus
- clean up icon components by removing unused strokeWidth props

## Testing
- `npm run build` *(fails: Cannot find package 'pyodide')*


------
https://chatgpt.com/codex/tasks/task_e_688edf09b33c832fbb9a1670d72dc761