### PR TITLE
fix: align svelte dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.2.6",
 		"sass-embedded": "^1.81.0",
-               "svelte": "^5.0.0-next.0",
+               "svelte": "^4.2.19",
 		"svelte-check": "^3.8.5",
 		"svelte-confetti": "^1.3.2",
 		"tailwindcss": "^4.0.0",


### PR DESCRIPTION
## Summary
- align `svelte` dev dependency to v4 to match package-lock and dependent packages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ee5195c64832fb0c0b9f0b961abdd