### PR TITLE
chore: remove unused color prop

### DIFF
--- a/src/lib/components/admin/Users/Groups/Display.svelte
+++ b/src/lib/components/admin/Users/Groups/Display.svelte
@@ -6,7 +6,6 @@
 	const i18n = getContext('i18n');
 
 	export let name = '';
-	export let color = '';
 	export let description = '';
 </script>
 


### PR DESCRIPTION
## Summary
- remove unused `color` export from Users/Groups Display component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688ee9fe42f8832fb231cb5d8976aa62