### PR TITLE
refactor: remove unused token prop

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/AlertRenderer.svelte
+++ b/src/lib/components/chat/Messages/Markdown/AlertRenderer.svelte
@@ -71,7 +71,6 @@
 	import MarkdownTokens from './MarkdownTokens.svelte';
 	import type { ComponentType } from 'svelte';
 
-	export let token: Token;
 	export let alert: AlertData;
 	export let id = '';
 	export let tokenIdx = 0;

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -176,7 +176,7 @@
 	{:else if token.type === 'blockquote'}
 		{@const alert = alertComponent(token)}
 		{#if alert}
-			<AlertRenderer {token} {alert} />
+			<AlertRenderer {alert} />
 		{:else}
 			<blockquote dir="auto">
 				<svelte:self id={`${id}-${tokenIdx}`} tokens={token.tokens} {onTaskClick} {onSourceClick} />


### PR DESCRIPTION
## Summary
- remove unused token prop from `AlertRenderer`
- adjust `MarkdownTokens` to stop passing unused prop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend`


------
https://chatgpt.com/codex/tasks/task_e_688eea2b853c832fa91d8265921bb054