### PR TITLE
refactor: remove unused socket.io import

### DIFF
--- a/src/lib/components/admin/Settings/Connections/OpenAIConnection.svelte
+++ b/src/lib/components/admin/Settings/Connections/OpenAIConnection.svelte
@@ -8,7 +8,6 @@
 	import AddConnectionModal from '$lib/components/AddConnectionModal.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 
-	import { connect } from 'socket.io-client';
 
 	export let onDelete = () => {};
 	export let onSubmit = () => {};


### PR DESCRIPTION
## Summary
- remove unused socket.io-client import from OpenAIConnection component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file; svelte-kit and pylint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eea2e5c00832f8d51d2cb64f8bda2