### PR TITLE
chore: remove unused roundArrow import

### DIFF
--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -4,8 +4,7 @@
 	import { onDestroy } from 'svelte';
 	import { marked } from 'marked';
 
-	import tippy from 'tippy.js';
-	import { roundArrow } from 'tippy.js';
+        import tippy from 'tippy.js';
 
 	export let placement = 'top';
 	export let content = `I'm a tooltip!`;


### PR DESCRIPTION
## Summary
- remove unused `roundArrow` from Tooltip import

## Testing
- `npx eslint -c .eslintrc.cjs src/lib/components/common/Tooltip.svelte` *(warn: File ignored because no matching configuration was supplied)*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688eea31fca0832fb022541773db733c