### PR TITLE
chore: remove unused imports in RichTextInput

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -11,8 +11,7 @@
 	import { createEventDispatcher } from 'svelte';
 	const eventDispatch = createEventDispatcher();
 
-	import { EditorState, Plugin, PluginKey, TextSelection } from 'prosemirror-state';
-	import { Decoration, DecorationSet } from 'prosemirror-view';
+        import { TextSelection } from 'prosemirror-state';
 
 	import { Editor } from '@tiptap/core';
 


### PR DESCRIPTION
## Summary
- remove unused prosemirror imports, keeping only TextSelection in RichTextInput

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found; install blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_688eea35c134832fb2dca5e4ebb90312