### PR TITLE
chore: remove unused postcss import

### DIFF
--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -24,9 +24,8 @@
 	import MenuLines from '../icons/MenuLines.svelte';
 	import AdjustmentsHorizontal from '../icons/AdjustmentsHorizontal.svelte';
 	import Map from '../icons/Map.svelte';
-	import { stringify } from 'postcss';
-	import PencilSquare from '../icons/PencilSquare.svelte';
-	import Plus from '../icons/Plus.svelte';
+        import PencilSquare from '../icons/PencilSquare.svelte';
+        import Plus from '../icons/Plus.svelte';
 
 	const i18n = getContext('i18n');
 


### PR DESCRIPTION
## Summary
- remove unused PostCSS stringify import from Navbar component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm ci` *(fails: ENETUNREACH when installing onnxruntime-node)*
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_688eea3ab29c832f8010657d35adc4f5