### PR TITLE
chore: remove unused stringify import

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -14,7 +14,6 @@
 	import { getFunctions } from '$lib/apis/functions';
 	import { getKnowledgeBases } from '$lib/apis/knowledge';
 	import AccessControl from '../common/AccessControl.svelte';
-	import { stringify } from 'postcss';
 	import { toast } from 'svelte-sonner';
 
 	const i18n = getContext('i18n');


### PR DESCRIPTION
## Summary
- remove unused stringify import from ModelEditor component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npx eslint src/lib/components/workspace/Models/ModelEditor.svelte` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_688eee2e2c24832f9e7eeb7f597e4632