### PR TITLE
chore: remove unused min import

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -13,7 +13,6 @@
 	import Overview from './Overview.svelte';
 	import EllipsisVertical from '../icons/EllipsisVertical.svelte';
 	import Artifacts from './Artifacts.svelte';
-	import { min } from '@floating-ui/utils';
 
 	export let history;
 	export let models = [];


### PR DESCRIPTION
## Summary
- remove unused `min` import from chat controls component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: ENETUNREACH during onnxruntime-node install)*
- `npm run lint` *(fails: ESLint config and dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_688eee368a50832fa232563ccaced4fe