### PR TITLE
chore: remove unused round import

### DIFF
--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -7,9 +7,8 @@
 	import { getVoices as _getVoices } from '$lib/apis/audio';
 
 	import Switch from '$lib/components/common/Switch.svelte';
-	import { round } from '@huggingface/transformers';
-	import Spinner from '$lib/components/common/Spinner.svelte';
-	const dispatch = createEventDispatcher();
+        import Spinner from '$lib/components/common/Spinner.svelte';
+        const dispatch = createEventDispatcher();
 
 	const i18n = getContext('i18n');
 


### PR DESCRIPTION
## Summary
- remove unused `round` import from audio settings component

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eee3dedb8832fb16b1e75e78fbcd6