### PR TITLE
chore: remove unused i18next import in channel api

### DIFF
--- a/src/lib/apis/channels/index.ts
+++ b/src/lib/apis/channels/index.ts
@@ -1,5 +1,4 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
-import { t } from 'i18next';
 
 type ChannelForm = {
 	name: string;


### PR DESCRIPTION
## Summary
- remove unused i18next import from channel API helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm ci` *(fails: onnxruntime-node install: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688eee43dd44832f9e4b1370aaa4e591