### PR TITLE
chore: bump svelte to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.2.6",
 		"sass-embedded": "^1.81.0",
-               "svelte": "^4.2.19",
+               "svelte": "^5.0.0",
 		"svelte-check": "^3.8.5",
 		"svelte-confetti": "^1.3.2",
 		"tailwindcss": "^4.0.0",


### PR DESCRIPTION
## Summary
- upgrade Svelte dev dependency to v5

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org/svelte)*
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ef1b0aa40832fb328f09ff1c851de