### PR TITLE
feat: default WhisperSpeech TTS model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ For more information, be sure to check out OpenwebUI documentation [Open WebUI D
 ## Deployment Configuration
 
 - `GUNICORN_TIMEOUT` – Gunicorn worker timeout in seconds (default: `120`).
+- `AUDIO_TTS_MODEL` – Text-to-speech model (default: `tts-1`, or `collabora/whisperspeech:s2a-q4-base-en+pl.model` when `AUDIO_TTS_ENGINE` is `whisperspeech`). Set this environment variable to override the default.

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2491,11 +2491,20 @@ AUDIO_TTS_ENGINE = PersistentConfig(
     os.getenv("AUDIO_TTS_ENGINE", ""),
 )
 
+# Default model for WhisperSpeech TTS engine
+DEFAULT_WHISPERSPEECH_TTS_MODEL = (
+    "collabora/whisperspeech:s2a-q4-base-en+pl.model"
+)
 
+default_tts_model = "tts-1"  # OpenAI default model
+if str(AUDIO_TTS_ENGINE.value).lower() == "whisperspeech":
+    default_tts_model = DEFAULT_WHISPERSPEECH_TTS_MODEL
+
+# Allow override via AUDIO_TTS_MODEL environment variable
 AUDIO_TTS_MODEL = PersistentConfig(
     "AUDIO_TTS_MODEL",
     "audio.tts.model",
-    os.getenv("AUDIO_TTS_MODEL", "tts-1"),  # OpenAI default model
+    os.getenv("AUDIO_TTS_MODEL", default_tts_model),
 )
 
 AUDIO_TTS_VOICE = PersistentConfig(


### PR DESCRIPTION
## Summary
- use WhisperSpeech model as default TTS when AUDIO_TTS_ENGINE is `whisperspeech` and allow override via AUDIO_TTS_MODEL env var
- document AUDIO_TTS_MODEL environment variable for configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util'; ModuleNotFoundError: No module named 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_688f76f907ec832f85edd1a25d1e6a36