### PR TITLE
Integrate WhisperSpeech dependency and import for audio TTS

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -28,6 +28,7 @@ from requests.adapters import HTTPAdapter
 import mimetypes
 from urllib.parse import urlparse  # ENH CWE-327
 from urllib3.util.retry import Retry
+import soundfile as sf
 
 
 from fastapi import (
@@ -553,8 +554,6 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             )
 
     elif request.app.state.config.TTS_ENGINE == "whisperspeech":
-        import soundfile as sf
-
         try:
             if getattr(request.app.state, "whisperspeech_pipe", None) is None:
                 from whisperspeech.pipeline import Pipeline
@@ -589,7 +588,6 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             raise HTTPException(status_code=400, detail="Invalid JSON payload")
 
         import torch
-        import soundfile as sf
 
         load_speech_pipeline(request)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -92,6 +92,7 @@ fpdf2==2.8.2
 rank-bm25==0.2.2
 
 faster-whisper==1.1.1
+WhisperSpeech==0.8.9
 
 PyJWT[crypto]==2.10.1
 authlib==1.4.1


### PR DESCRIPTION
## Summary
- add `soundfile` module import and WhisperSpeech pipeline loader
- declare WhisperSpeech package in backend requirements

## Testing
- `python -m py_compile backend/open_webui/routers/audio.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_688f6289664c832fb7828bc16e490f26