### PR TITLE
feat(auth): add localized footer

### DIFF
--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1213,5 +1213,6 @@
 	"Your entire contribution will go directly to the plugin developer; Open WebUI does not take any percentage. However, the chosen funding platform might have its own fees.": "",
 	"Youtube": "",
 	"Youtube Language": "",
-	"Youtube Proxy URL": ""
+	"Youtube Proxy URL": "",
+	"© 2025 Ameritas Mutual Holding Company": ""
 }

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -267,8 +267,11 @@ Modification Log:
 										{$i18n.t(`Sign in to {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 									{:else}
 										{$i18n.t(`Sign up to {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
-									{/if}
-								</div>
+{/if}
+<footer class="absolute bottom-4 w-full text-center text-xs text-gray-500 dark:text-gray-400 font-primary">
+{$i18n.t('© 2025 Ameritas Mutual Holding Company')}
+</footer>
+</div>
 
 								{#if $config?.onboarding ?? false}
 									<div class=" mt-1 text-xs font-medium text-gray-500">
@@ -521,4 +524,7 @@ Modification Log:
 			</div>
 		</div>
 	{/if}
+	<footer class="absolute bottom-4 w-full text-center text-xs text-gray-500 dark:text-gray-400 font-primary">
+		{$i18n.t('© 2025 Ameritas Mutual Holding Company')}
+	</footer>
 </div>


### PR DESCRIPTION
## Summary
- add localized copyright footer to auth page
- provide translation entry for new footer text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8b56a3b8832f9605273598aee036