### PR TITLE
Use GPU for Whisper pipeline when available

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -819,9 +819,13 @@ if app.state.config.TTS_ENGINE == "whisperspeech":
         app.state.config.TTS_MODEL = DEFAULT_WHISPERSPEECH_TTS_MODEL
     try:
         from whisperspeech.pipeline import Pipeline
+        import torch
+
+        device = 0 if torch.cuda.is_available() else "cpu"
 
         app.state.whisperspeech_pipe = Pipeline.from_pretrained(
-            s2a_ref=app.state.config.TTS_MODEL
+            s2a_ref=app.state.config.TTS_MODEL,
+            device=device,
         )
     except Exception as e:
         log.warning(f"Failed to preload WhisperSpeech pipeline: {e}")

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -558,6 +558,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             if getattr(request.app.state, "whisperspeech_pipe", None) is None:
                 try:
                     from whisperspeech.pipeline import Pipeline
+                    import torch
                 except ModuleNotFoundError as e:
                     log.exception(e)
                     missing = getattr(e, "name", "")
@@ -567,8 +568,11 @@ async def speech(request: Request, user=Depends(get_verified_user)):
                         detail = "Install WhisperSpeech to use this engine"
                     raise HTTPException(status_code=500, detail=detail)
 
+                device = 0 if torch.cuda.is_available() else "cpu"
+
                 request.app.state.whisperspeech_pipe = Pipeline.from_pretrained(
-                    s2a_ref=request.app.state.config.TTS_MODEL
+                    s2a_ref=request.app.state.config.TTS_MODEL,
+                    device=device,
                 )
 
             pipe = request.app.state.whisperspeech_pipe


### PR DESCRIPTION
## Summary
- detect CUDA availability and pass a GPU device when preloading the WhisperSpeech pipeline
- apply the same GPU-aware loading when generating speech so CPU mode is only used as fallback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_688f94759150832fb8ad8ed5c03c46ff