### PR TITLE
Use direct WhisperSpeech Pipeline

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -823,7 +823,8 @@ if app.state.config.TTS_ENGINE == "whisperspeech":
 
         device = 0 if torch.cuda.is_available() else "cpu"
 
-        app.state.whisperspeech_pipe = Pipeline.from_pretrained(
+        app.state.whisperspeech_pipe = Pipeline(
+            t2s_ref="whisperspeech/whisperspeech:t2s-v1.95-small-8lang.model",
             s2a_ref=app.state.config.TTS_MODEL,
             device=device,
         )

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -570,7 +570,8 @@ async def speech(request: Request, user=Depends(get_verified_user)):
 
                 device = 0 if torch.cuda.is_available() else "cpu"
 
-                request.app.state.whisperspeech_pipe = Pipeline.from_pretrained(
+                request.app.state.whisperspeech_pipe = Pipeline(
+                    t2s_ref="whisperspeech/whisperspeech:t2s-v1.95-small-8lang.model",
                     s2a_ref=request.app.state.config.TTS_MODEL,
                     device=device,
                 )


### PR DESCRIPTION
## Summary
- switch WhisperSpeech pipeline initialization to direct `Pipeline` calls
- provide both `t2s_ref` and `s2a_ref` when creating the pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_688f9a559f28832f8ad9d140bcbb91e4