### PR TITLE
Enable optional CUDA for WhisperSpeech pipelines

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -820,14 +820,12 @@ if app.state.config.TTS_ENGINE == "whisperspeech":
     try:
         from whisperspeech.pipeline import Pipeline
         import torch
-
-        device = 0 if torch.cuda.is_available() else "cpu"
-
         app.state.whisperspeech_pipe = Pipeline(
             t2s_ref="whisperspeech/whisperspeech:t2s-v1.95-small-8lang.model",
             s2a_ref=app.state.config.TTS_MODEL,
-            device=device,
         )
+        if torch.cuda.is_available():
+            app.state.whisperspeech_pipe.to("cuda")
     except Exception as e:
         log.warning(f"Failed to preload WhisperSpeech pipeline: {e}")
 


### PR DESCRIPTION
## Summary
- move WhisperSpeech pipelines to CUDA when available with CPU fallback
- detect CUDA when loading text-to-speech pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util', No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_688f9de943e8832fae93e26e5023ab36