### PR TITLE
chore: centralize model caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,11 @@ ENV TIKTOKEN_ENCODING_NAME="cl100k_base" \
     TIKTOKEN_CACHE_DIR="/app/backend/data/cache/tiktoken"
 
 ## Hugging Face download cache ##
-ENV HF_HOME="/app/backend/data/cache/embedding/models"
+ENV HF_HOME="/app/backend/data/cache/huggingface"
+ENV XDG_CACHE_HOME="/app/backend/data/cache"
+ENV TORCH_HOME="/app/backend/data/cache/torch"
+ENV HF_DATASETS_CACHE="/app/backend/data/cache/huggingface/datasets"
+ENV TRANSFORMERS_CACHE="/app/backend/data/cache/huggingface"
 
 ## Torch Extensions ##
 # ENV TORCH_EXTENSIONS_DIR="/.cache/torch_extensions"

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -327,6 +327,16 @@ if FROM_INIT_PY:
         os.getenv("FRONTEND_BUILD_DIR", OPEN_WEBUI_DIR / "frontend")
     ).resolve()
 
+CACHE_DIR = DATA_DIR / "cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("XDG_CACHE_HOME", str(CACHE_DIR))
+os.environ.setdefault("TORCH_HOME", str(CACHE_DIR / "torch"))
+os.environ.setdefault("HF_HOME", str(CACHE_DIR / "huggingface"))
+os.environ.setdefault("HF_DATASETS_CACHE", str(CACHE_DIR / "huggingface" / "datasets"))
+os.environ.setdefault("TRANSFORMERS_CACHE", str(CACHE_DIR / "huggingface"))
+for env_var in ("TORCH_HOME", "HF_HOME", "HF_DATASETS_CACHE", "TRANSFORMERS_CACHE"):
+    Path(os.environ[env_var]).mkdir(parents=True, exist_ok=True)
+
 ####################################
 # Whisper model directory
 ####################################

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -182,8 +182,14 @@ export DATABASE_URL="postgresql://${POSTGRESQL_USERID}:${POSTGRESQL_PASSCODE}@${
 # Additional non-SSM environment variables
 export ALLOWED_MODULES_FILE="ALLOWED_MODULES.json"
 export SENTENCE_TRANSFORMERS_HOME=$SCRIPT_DIR/data/cache/embedding/models
+export XDG_CACHE_HOME=$SCRIPT_DIR/data/cache
+export TORCH_HOME=$SCRIPT_DIR/data/cache/torch
+export HF_HOME=$SCRIPT_DIR/data/cache/huggingface
+export HF_DATASETS_CACHE=$SCRIPT_DIR/data/cache/huggingface/datasets
+export TRANSFORMERS_CACHE=$SCRIPT_DIR/data/cache/huggingface
 export S3_REGION_NAME="$AWS_REGION"
 
+mkdir -p "$XDG_CACHE_HOME" "$TORCH_HOME" "$HF_HOME" "$HF_DATASETS_CACHE" "$SENTENCE_TRANSFORMERS_HOME"
 
 LOGS_DIR="$SCRIPT_DIR"/logs
 


### PR DESCRIPTION
## Summary
- scope backend cache dirs and exports
- configure Docker cache env vars
- set default cache env vars in Python

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*
- `python - <<'PY'
import os, pathlib
os.environ['ALLOWED_MODULES_FILE'] = 'ALLOWED_MODULES.json'
from open_webui import env
print('HF_HOME:', os.environ.get('HF_HOME'))
from transformers import AutoModel
AutoModel.from_pretrained('sshleifer/tiny-distilroberta-base')
PY` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fa704b7cc832f8471e3923baa01d0