### PR TITLE
Handle default voice for WhisperSpeech

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -577,7 +577,17 @@ async def speech(request: Request, user=Depends(get_verified_user)):
                     request.app.state.whisperspeech_pipe.to("cuda")
 
             pipe = request.app.state.whisperspeech_pipe
-            audio = pipe.generate(payload["input"], speaker=payload.get("voice"))
+
+            voice = payload.get("voice")
+            if not voice or voice == "default":
+                speaker = None
+            else:
+                available_voices = get_available_voices(request)
+                if voice not in available_voices:
+                    raise HTTPException(status_code=400, detail="Invalid voice id")
+                speaker = voice
+
+            audio = pipe.generate(payload["input"], speaker=speaker)
 
             sf.write(file_path, audio, 24000)
 


### PR DESCRIPTION
## Summary
- Normalize WhisperSpeech voice selection by treating missing or "default" voices as `None`
- Validate provided voice IDs and return a clear error for unknown voices

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/apps/webui/routers/test_audio.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688faed431c4832f848c1ff4ee59e48f