### PR TITLE
Add dedicated log paths and handlers

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -16,7 +16,6 @@ import sys
 import shutil
 from pathlib import Path
 import builtins           #AMER-ENH
-from datetime import datetime
 
 import markdown
 from bs4 import BeautifulSoup
@@ -125,10 +124,15 @@ log.setLevel(SRC_LOG_LEVELS["CONFIG"])
 
 LOGS_DIR = BACKEND_DIR / "logs"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
-current_date = datetime.now().strftime("%m_%d_%y")
-APP_ERROR_LOG_PATH = LOGS_DIR / f"backendlog_error_{current_date}.log"
-APP_ADMIN_ACTIVITY_LOG_PATH = LOGS_DIR / f"backendlog_admin_activity_{current_date}.log"
-GUNICORN_CRASH_LOG_PATH = LOGS_DIR / f"backendlog_gunicorn_crash_{current_date}.log"
+APP_ERROR_LOG_PATH = Path(
+    os.environ.get("APP_ERROR_LOG_PATH", LOGS_DIR / "backendlog_error.log")
+)
+APP_ADMIN_ACTIVITY_LOG_PATH = Path(
+    os.environ.get("APP_ADMIN_ACTIVITY_LOG_PATH", LOGS_DIR / "backendlog_admin_activity.log")
+)
+GUNICORN_CRASH_LOG_PATH = Path(
+    os.environ.get("GUNICORN_CRASH_LOG_PATH", LOGS_DIR / "backendlog_gunicorn_crash.log")
+)
 
 ##Start of AMER-ENH
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -16,6 +16,7 @@ import sys
 import shutil
 from pathlib import Path
 import builtins           #AMER-ENH
+from datetime import datetime
 
 import markdown
 from bs4 import BeautifulSoup
@@ -124,9 +125,10 @@ log.setLevel(SRC_LOG_LEVELS["CONFIG"])
 
 LOGS_DIR = BACKEND_DIR / "logs"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
-APP_ERROR_LOG_PATH = LOGS_DIR / "app_error.log"
-APP_ADMIN_ACTIVITY_LOG_PATH = LOGS_DIR / "admin_activity.log"
-GUNICORN_CRASH_LOG_PATH = LOGS_DIR / "gunicorn_crash.log"
+current_date = datetime.now().strftime("%m_%d_%y")
+APP_ERROR_LOG_PATH = LOGS_DIR / f"backendlog_error_{current_date}.log"
+APP_ADMIN_ACTIVITY_LOG_PATH = LOGS_DIR / f"backendlog_admin_activity_{current_date}.log"
+GUNICORN_CRASH_LOG_PATH = LOGS_DIR / f"backendlog_gunicorn_crash_{current_date}.log"
 
 ##Start of AMER-ENH
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -122,6 +122,12 @@ for source in log_sources:
 
 log.setLevel(SRC_LOG_LEVELS["CONFIG"])
 
+LOGS_DIR = BACKEND_DIR / "logs"
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+APP_ERROR_LOG_PATH = LOGS_DIR / "app_error.log"
+APP_ADMIN_ACTIVITY_LOG_PATH = LOGS_DIR / "admin_activity.log"
+GUNICORN_CRASH_LOG_PATH = LOGS_DIR / "gunicorn_crash.log"
+
 ##Start of AMER-ENH
 
 WEBUI_NAME = os.environ.get("WEBUI_NAME", "AmeritasGPT")

--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -10,6 +10,8 @@ from open_webui.env import (
     AUDIT_LOG_LEVEL,
     AUDIT_LOGS_FILE_PATH,
     GLOBAL_LOG_LEVEL,
+    APP_ERROR_LOG_PATH,
+    APP_ADMIN_ACTIVITY_LOG_PATH,
 )
 
 
@@ -110,6 +112,14 @@ def start_logger():
         level=GLOBAL_LOG_LEVEL,
         format=stdout_format,
         filter=lambda record: "auditable" not in record["extra"],
+    )
+
+    logger.add(APP_ERROR_LOG_PATH, level="ERROR")
+
+    logger.add(
+        APP_ADMIN_ACTIVITY_LOG_PATH,
+        level="INFO",
+        filter=lambda record: record["extra"].get("admin_activity") is True,
     )
 
     if AUDIT_LOG_LEVEL != "NONE":

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -260,6 +260,7 @@ echo "Starting Scout"
 
 current_date=$(date +"%m_%d_%y")
 export LOG_FILENAME="$LOGS_DIR/backendlog_${current_date}.log"
+export GUNICORN_CRASH_LOG_PATH="$LOGS_DIR/gunicorn_crash.log"
 
 # Preprocess the log_config_template.yaml to replace placeholders with actual values
 sed "s|__GLOBAL_LOG_LEVEL__|$GLOBAL_LOG_LEVEL|g; s|__LOG_FILENAME__|$LOG_FILENAME|g" uvicorn_logconfig_template.ini > "$LOG_CONFIG"
@@ -272,5 +273,6 @@ gunicorn open_webui.main:app \
     --workers "$WORKERS" \
     --log-config "$LOG_CONFIG" \
     --access-logfile - \
-    --timeout "${GUNICORN_TIMEOUT:-120}" 
-    --log-level "$LOG_LVL"
+    --timeout "${GUNICORN_TIMEOUT:-120}" \
+    --log-level "$LOG_LVL" \
+    --error-logfile "$GUNICORN_CRASH_LOG_PATH"

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -260,6 +260,8 @@ echo "Starting Scout"
 
 current_date=$(date +"%m_%d_%y")
 export LOG_FILENAME="$LOGS_DIR/backendlog_${current_date}.log"
+export APP_ERROR_LOG_PATH="$LOGS_DIR/backendlog_error_${current_date}.log"
+export APP_ADMIN_ACTIVITY_LOG_PATH="$LOGS_DIR/backendlog_admin_activity_${current_date}.log"
 export GUNICORN_CRASH_LOG_PATH="$LOGS_DIR/backendlog_gunicorn_crash_${current_date}.log"
 
 # Preprocess the log_config_template.yaml to replace placeholders with actual values

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -260,7 +260,7 @@ echo "Starting Scout"
 
 current_date=$(date +"%m_%d_%y")
 export LOG_FILENAME="$LOGS_DIR/backendlog_${current_date}.log"
-export GUNICORN_CRASH_LOG_PATH="$LOGS_DIR/gunicorn_crash.log"
+export GUNICORN_CRASH_LOG_PATH="$LOGS_DIR/backendlog_gunicorn_crash_${current_date}.log"
 
 # Preprocess the log_config_template.yaml to replace placeholders with actual values
 sed "s|__GLOBAL_LOG_LEVEL__|$GLOBAL_LOG_LEVEL|g; s|__LOG_FILENAME__|$LOG_FILENAME|g" uvicorn_logconfig_template.ini > "$LOG_CONFIG"


### PR DESCRIPTION
## Summary
- define log paths for error, admin activity, and gunicorn crash logs
- add Loguru handlers for error and admin activity logs
- route gunicorn crash output to dedicated log file

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_688fbc88bbe0832f85d8138b7e25fc01