### PR TITLE
Fix tuple creation in send_get_request headers

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -124,7 +124,7 @@ async def send_get_request(
                                 "X-Scout-User-Role": user.role,
                             }
                             if ENABLE_FORWARD_USER_INFO_HEADERS and user
-                            else {},
+                            else {}
                         ),
                     },
                 ) as response:


### PR DESCRIPTION
## Summary
- prevent tuple creation when forwarding user info headers in `send_get_request`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*
- `python -m py_compile backend/open_webui/routers/openai.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe80127ac832fa64a1bfe7a0af369