### PR TITLE
chore: route standard logging through loguru

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -1,5 +1,7 @@
+import inspect
 import json
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -17,6 +19,64 @@ from open_webui.env import (
 if TYPE_CHECKING:
     from loguru import Record
 
+
+
+class InterceptHandler(logging.Handler):
+    """Routes standard logging records to Loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        frame, depth = inspect.currentframe(), 2
+        while frame and os.path.abspath(frame.f_code.co_filename) in (
+            os.path.abspath(logging.__file__),
+            __file__,
+        ):
+            frame = frame.f_back
+            depth += 1
+
+        function = record.funcName if record.funcName != "<module>" else record.name
+
+        # Extract any custom attributes attached via ``extra`` on the standard log record
+        # so they can be leveraged by Loguru (e.g., ``admin_activity``).
+        standard_attrs = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+        }
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in standard_attrs
+        }
+
+        log = logger.bind(**extras) if extras else logger
+
+        log.patch(
+            lambda r: r.update(
+                name=record.name, function=function, module=record.module, line=record.lineno
+            )
+        ).opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 
@@ -85,4 +145,6 @@ def start_logger():
         except Exception as e:
             logger.error(f"Failed to initialize audit log file handler: {str(e)}")
 
-    logging.getLogger(__name__).info(f"GLOBAL_LOG_LEVEL: {GLOBAL_LOG_LEVEL}")
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
+
+    logger.info(f"GLOBAL_LOG_LEVEL: {GLOBAL_LOG_LEVEL}")


### PR DESCRIPTION
## Summary
- redirect Python's standard logging records to Loguru via an intercept handler
- ensure interceptor maps `<module>` records to their module names so log entries report accurate origins
- initialize Loguru at startup so error and admin-activity logs share Loguru's configured outputs
- forward custom logging extras so `admin_activity` events reach the dedicated log file

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test -q` *(fails: ModuleNotFoundError: No module named 'test.util'; ModuleNotFoundError: No module named 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_688fde453c04832fa2e37a1b7ae4c0a0