### PR TITLE
feat: highlight greeting text in blue

### DIFF
--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -82,9 +82,9 @@
 			class=" mt-2 mb-4 text-3xl text-gray-800 dark:text-gray-100 font-medium text-left flex items-center gap-4 font-primary"
 		>
 			<div>
-				<div class=" capitalize line-clamp-1" in:fade={{ duration: 200 }}>
-					{$i18n.t('Hello, {{name}}', { name: $user.name })}					
-				</div>
+                                <div class=" capitalize line-clamp-1 text-[#4285F4] dark:text-[#4285F4]" in:fade={{ duration: 200 }}>
+                                        {$i18n.t('Hello, {{name}}', { name: $user.name })}
+                                </div>
 
 				<div in:fade={{ duration: 200, delay: 200 }}>
 					{#if models[selectedModelIdx]?.info?.meta?.description ?? null}

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -138,9 +138,9 @@
 					</div>
 				</div>
 
-				<div class=" text-3xl @sm:text-4xl line-clamp-1" in:fade={{ duration: 100 }}>
-						{$i18n.t('Hello, {{name}}', { name: $user.name })}
-				</div>
+                                <div class=" text-3xl @sm:text-4xl line-clamp-1 text-[#4285F4] dark:text-[#4285F4]" in:fade={{ duration: 100 }}>
+                                                {$i18n.t('Hello, {{name}}', { name: $user.name })}
+                                </div>
 			</div>
 
 			<div class="flex mt-1 mb-2">


### PR DESCRIPTION
## Summary
- style blue greeting text in chat placeholder
- style blue greeting text in placeholder

## Testing
- `npm run lint` *(fails: eslint, svelte-kit, pylint not found)*
- `npm run build` *(fails: Cannot find package 'pyodide')*


------
https://chatgpt.com/codex/tasks/task_e_688ff5202c98832fa5062baa29744cab