### PR TITLE
Save WhisperSpeech output as WAV

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -380,7 +380,10 @@ async def speech(request: Request, user=Depends(get_verified_user)):
         + str(request.app.state.config.TTS_MODEL).encode("utf-8")
     ).hexdigest()
 
-    file_path = SPEECH_CACHE_DIR.joinpath(f"{name}.mp3")
+    extension = (
+        "wav" if request.app.state.config.TTS_ENGINE == "whisperspeech" else "mp3"
+    )
+    file_path = SPEECH_CACHE_DIR.joinpath(f"{name}.{extension}")
     file_body_path = SPEECH_CACHE_DIR.joinpath(f"{name}.json")
 
     # Check if the file already exists in the cache
@@ -590,7 +593,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             audio = pipe.generate(payload["input"], speaker=speaker)
             if isinstance(audio, torch.Tensor):
                 audio = audio.detach().cpu().numpy()
-            sf.write(file_path, audio, 24000)
+            sf.write(file_path, audio, 24000, format="WAV")
 
             async with aiofiles.open(file_body_path, "w") as f:
                 await f.write(json.dumps(payload))


### PR DESCRIPTION
## Summary
- store WhisperSpeech TTS output as WAV instead of MP3
- add regression test ensuring WhisperSpeech audio is saved and playable

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/apps/webui/routers/test_audio.py::TestAudioRouter::test_whisperspeech_audio_saved_and_playable -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff45b6b20832fa910b2f4f681bb34