### PR TITLE
fix whisperspeech device handling

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -572,12 +572,12 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             if getattr(request.app.state, "whisperspeech_pipe", None) is None:
                 from whisperspeech.pipeline import Pipeline
 
+                device = "cuda" if torch.cuda.is_available() else None
                 request.app.state.whisperspeech_pipe = Pipeline(
                     t2s_ref="whisperspeech/whisperspeech:t2s-v1.95-small-8lang.model",
                     s2a_ref=request.app.state.config.TTS_MODEL,
+                    device=device,
                 )
-                if torch.cuda.is_available():
-                    request.app.state.whisperspeech_pipe.to("cuda")
 
             pipe = request.app.state.whisperspeech_pipe
 


### PR DESCRIPTION
## Summary
- remove direct `.to("cuda")` call for WhisperSpeech and pass device during initialization instead

## Testing
- `python -m py_compile backend/open_webui/routers/audio.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui', 'test.util', 'moto')*
- `python - <<'PY'
import torch, types, sys, numpy as np

# stub pipeline
class DummyPipeline:
    def __init__(self, t2s_ref=None, s2a_ref=None, device=None):
        self.device = device
    def generate(self, text, speaker=None):
        return np.zeros(1)

pipeline_module = types.ModuleType('whisperspeech.pipeline')
pipeline_module.Pipeline = DummyPipeline
sys.modules['whisperspeech'] = types.ModuleType('whisperspeech')
sys.modules['whisperspeech.pipeline'] = pipeline_module

def init_pipe():
    from whisperspeech.pipeline import Pipeline
    device = "cuda" if torch.cuda.is_available() else None
    return Pipeline(t2s_ref="t2s", s2a_ref="s2a", device=device)

pipe = init_pipe()
print('cuda available:', torch.cuda.is_available(), '-> device', pipe.device)
orig = torch.cuda.is_available
torch.cuda.is_available = lambda: True
pipe2 = init_pipe()
print('cuda forced available:', torch.cuda.is_available(), '-> device', pipe2.device)
torch.cuda.is_available = orig
PY`

------
https://chatgpt.com/codex/tasks/task_e_689003ffaf48832fb45fd4de0bc8e63c