### PR TITLE
Add Optimize prompt translation key

### DIFF
--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -788,6 +788,7 @@
 	"OpenAI API Key is required.": "OpenAI API.مطلوب مفتاح ",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/مفتاح OpenAI.مطلوب عنوان ",
+        "Optimize prompt": "",
 	"or": "أو",
 	"Organize your users": "",
 	"Other": "آخر",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -788,6 +788,7 @@
 	"OpenAI API Key is required.": "OpenAI API ключ е задължителен.",
 	"OpenAI API settings updated": "Настройките на OpenAI API са актуализирани",
 	"OpenAI URL/Key required.": "OpenAI URL/Key е задължителен.",
+        "Optimize prompt": "",
 	"or": "или",
 	"Organize your users": "Организирайте вашите потребители",
 	"Other": "Друго",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API কোড আবশ্যক",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/Key আবশ্যক",
+        "Optimize prompt": "",
 	"or": "অথবা",
 	"Organize your users": "",
 	"Other": "অন্যান্য",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -788,6 +788,7 @@
 	"OpenAI API Key is required.": "Es requereix la clau API d'OpenAI.",
 	"OpenAI API settings updated": "Configuració de l'API d'OpenAI actualitzada",
 	"OpenAI URL/Key required.": "URL/Clau d'OpenAI requerides.",
+        "Optimize prompt": "",
 	"or": "o",
 	"Organize your users": "Organitza els teus usuaris",
 	"Other": "Altres",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -788,6 +788,7 @@
 	"OpenAI API Key is required.": "Ang yawe sa OpenAI API gikinahanglan.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "",
+        "Optimize prompt": "",
 	"or": "O",
 	"Organize your users": "",
 	"Other": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Je vyžadován klíč OpenAI API.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Je vyžadován odkaz/adresa URL nebo klíč OpenAI.",
+        "Optimize prompt": "",
 	"or": "nebo",
 	"Organize your users": "",
 	"Other": "Jiné",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API-nøgle er påkrævet.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/nøgle påkrævet.",
+        "Optimize prompt": "",
 	"or": "eller",
 	"Organize your users": "",
 	"Other": "Andet",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI-API-Schlüssel erforderlich.",
 	"OpenAI API settings updated": "OpenAI-API-Einstellungen aktualisiert",
 	"OpenAI URL/Key required.": "OpenAI-URL/Schlüssel erforderlich.",
+        "Optimize prompt": "",
 	"or": "oder",
 	"Organize your users": "Organisieren Sie Ihre Benutzer",
 	"Other": "Andere",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI Bark Key is required.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "",
+        "Optimize prompt": "",
 	"or": "or",
 	"Organize your users": "",
 	"Other": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Απαιτείται το Κλειδί API OpenAI.",
 	"OpenAI API settings updated": "Οι ρυθμίσεις API OpenAI ενημερώθηκαν",
 	"OpenAI URL/Key required.": "Απαιτείται URL/Kλειδί OpenAI.",
+        "Optimize prompt": "",
 	"or": "ή",
 	"Organize your users": "Οργανώστε τους χρήστες σας",
 	"Other": "Άλλο",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "",
+        "Optimize prompt": "Optimize prompt",
 	"or": "",
 	"Organize your users": "",
 	"Other": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "",
+        "Optimize prompt": "Optimize prompt",
 	"or": "",
 	"Organize your users": "",
 	"Other": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Clave API de OpenAI requerida.",
 	"OpenAI API settings updated": "Ajustes de API OpenAI actualizados",
 	"OpenAI URL/Key required.": "URL/Clave de OpenAI requerida.",
+        "Optimize prompt": "",
 	"or": "o",
 	"Organize your users": "Organiza tus usuarios",
 	"Other": "Otro",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API võti on nõutav.",
 	"OpenAI API settings updated": "OpenAI API seaded uuendatud",
 	"OpenAI URL/Key required.": "OpenAI URL/võti on nõutav.",
+        "Optimize prompt": "",
 	"or": "või",
 	"Organize your users": "Korraldage oma kasutajad",
 	"Other": "Muu",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API gakoa beharrezkoa da.",
 	"OpenAI API settings updated": "OpenAI API ezarpenak eguneratu dira",
 	"OpenAI URL/Key required.": "OpenAI URL/Gakoa beharrezkoa da.",
+        "Optimize prompt": "",
 	"or": "edo",
 	"Organize your users": "Antolatu zure erabiltzaileak",
 	"Other": "Bestelakoa",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "مقدار کلید OpenAI API مورد نیاز است.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/Key OpenAI مورد نیاز است.",
+        "Optimize prompt": "",
 	"or": "یا",
 	"Organize your users": "",
 	"Other": "دیگر",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API -avain vaaditaan.",
 	"OpenAI API settings updated": "OpenAI API -asetukset päivitetty",
 	"OpenAI URL/Key required.": "OpenAI URL/avain vaaditaan.",
+        "Optimize prompt": "",
 	"or": "tai",
 	"Organize your users": "Järjestä käyttäjäsi",
 	"Other": "Muu",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Une clé API OpenAI est requise.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/Clé OpenAI requise.",
+        "Optimize prompt": "",
 	"or": "ou",
 	"Organize your users": "",
 	"Other": "Autre",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Une clé API OpenAI est requise.",
 	"OpenAI API settings updated": "Paramètres de l'API OpenAI mis à jour",
 	"OpenAI URL/Key required.": "URL/Clé OpenAI requise.",
+        "Optimize prompt": "",
 	"or": "ou",
 	"Organize your users": "Organisez vos utilisateurs",
 	"Other": "Autre",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -764,6 +764,7 @@
 	"OpenAI API Key is required.": "Achave da API de OpenAI es requerida.",
 	"OpenAI API settings updated": "Configuración de OpenAI API actualizada",
 	"OpenAI URL/Key required.": "URL/chave de OpenAI es requerida.",
+        "Optimize prompt": "",
 	"or": "ou",
 	"Organize your users": "Organiza os teus usuarios",
 	"Other": "Outro",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "נדרש מפתח API של OpenAI.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "נדרשת כתובת URL/מפתח של OpenAI.",
+        "Optimize prompt": "",
 	"or": "או",
 	"Organize your users": "",
 	"Other": "אחר",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API कुंजी आवश्यक है",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/Key आवश्यक है।",
+        "Optimize prompt": "",
 	"or": "या",
 	"Organize your users": "",
 	"Other": "अन्य",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Potreban je OpenAI API ključ.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Potreban je OpenAI URL/ključ.",
+        "Optimize prompt": "",
 	"or": "ili",
 	"Organize your users": "",
 	"Other": "Ostalo",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API kulcs szükséges.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/kulcs szükséges.",
+        "Optimize prompt": "",
 	"or": "vagy",
 	"Organize your users": "",
 	"Other": "Egyéb",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Diperlukan Kunci API OpenAI.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Diperlukan URL/Kunci OpenAI.",
+        "Optimize prompt": "",
 	"or": "atau",
 	"Organize your users": "",
 	"Other": "Lainnya",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Tá Eochair API OpenAI ag teastáil.",
 	"OpenAI API settings updated": "Nuashonraíodh socruithe OpenAI API",
 	"OpenAI URL/Key required.": "Teastaíonn URL/eochair OpenAI.",
+        "Optimize prompt": "",
 	"or": "nó",
 	"Organize your users": "Eagraigh do chuid úsáideoirí",
 	"Other": "Eile",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "La chiave API OpenAI è obbligatoria.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/Chiave OpenAI obbligatori.",
+        "Optimize prompt": "",
 	"or": "o",
 	"Organize your users": "",
 	"Other": "Altro",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API キーが必要です。",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/Key が必要です。",
+        "Optimize prompt": "",
 	"or": "または",
 	"Organize your users": "",
 	"Other": "その他",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API გასაღები აუცილებელია.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/Key აუცილებელია.",
+        "Optimize prompt": "",
 	"or": "ან",
 	"Organize your users": "",
 	"Other": "სხვა",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API 키가 필요합니다.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI URL/키가 필요합니다.",
+        "Optimize prompt": "",
 	"or": "또는",
 	"Organize your users": "사용자를 ",
 	"Other": "기타",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API raktas būtinas.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI API nuoroda ir raktas būtini",
+        "Optimize prompt": "",
 	"or": "arba",
 	"Organize your users": "",
 	"Other": "Kita",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Kekunci API OpenAI diperlukan",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/Kekunci OpenAI diperlukan",
+        "Optimize prompt": "",
 	"or": "atau",
 	"Organize your users": "",
 	"Other": "Lain-lain",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "API-nøkkel for OpenAI kreves.",
 	"OpenAI API settings updated": "API-innstillinger for OpenAI er oppdatert",
 	"OpenAI URL/Key required.": "URL/nøkkel for OpenAI kreves.",
+        "Optimize prompt": "",
 	"or": "eller",
 	"Organize your users": "Organisere brukerne dine",
 	"Other": "Annet",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API-sleutel is verplicht",
 	"OpenAI API settings updated": "OpenAI API-sleutel bijgewerkt",
 	"OpenAI URL/Key required.": "OpenAI URL/Sleutel vereist.",
+        "Optimize prompt": "",
 	"or": "of",
 	"Organize your users": "Orden je gebruikers",
 	"Other": "Andere",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "ਓਪਨਏਆਈ API ਕੁੰਜੀ ਦੀ ਲੋੜ ਹੈ।",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "ਓਪਨਏਆਈ URL/ਕੁੰਜੀ ਦੀ ਲੋੜ ਹੈ।",
+        "Optimize prompt": "",
 	"or": "ਜਾਂ",
 	"Organize your users": "",
 	"Other": "ਹੋਰ",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Klucz API OpenAI jest niezbędny.",
 	"OpenAI API settings updated": "Ustawienia API OpenAI zostały zaktualizowane",
 	"OpenAI URL/Key required.": "Wymagany jest URL/klucz OpenAI.",
+        "Optimize prompt": "",
 	"or": "lub",
 	"Organize your users": "Zorganizuj swoich użytkowników",
 	"Other": "Pozostałe",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Chave API OpenAI é necessária.",
 	"OpenAI API settings updated": "Configurações OpenAI atualizadas",
 	"OpenAI URL/Key required.": "URL/Chave OpenAI necessária.",
+        "Optimize prompt": "",
 	"or": "ou",
 	"Organize your users": "Organizar seus usuários",
 	"Other": "Outro",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "A Chave da API OpenAI é obrigatória.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "URL/Chave da API OpenAI é necessária.",
+        "Optimize prompt": "",
 	"or": "ou",
 	"Organize your users": "",
 	"Other": "Outro",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Este necesară cheia API OpenAI.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Este necesar URL-ul/Cheia OpenAI.",
+        "Optimize prompt": "",
 	"or": "sau",
 	"Organize your users": "",
 	"Other": "Altele",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Требуется ключ API OpenAI.",
 	"OpenAI API settings updated": "Настройки OpenAI API обновлены",
 	"OpenAI URL/Key required.": "Требуется URL-адрес API OpenAI или ключ API.",
+        "Optimize prompt": "",
 	"or": "или",
 	"Organize your users": "Организуйте своих пользователей",
 	"Other": "Прочее",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Je vyžadovaný kľúč OpenAI API.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Je vyžadovaný odkaz/adresa URL alebo kľúč OpenAI.",
+        "Optimize prompt": "",
 	"or": "alebo",
 	"Organize your users": "",
 	"Other": "Iné",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Потребан је OpenAI API кључ.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Потребан је OpenAI URL/кључ.",
+        "Optimize prompt": "",
 	"or": "или",
 	"Organize your users": "Организујте ваше кориснике",
 	"Other": "Остало",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API-nyckel krävs.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "OpenAI-URL/nyckel krävs.",
+        "Optimize prompt": "",
 	"or": "eller",
 	"Organize your users": "",
 	"Other": "Andra",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "จำเป็นต้องใช้คีย์ OpenAI API",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "จำเป็นต้องใช้ URL/คีย์ OpenAI",
+        "Optimize prompt": "",
 	"or": "หรือ",
 	"Organize your users": "",
 	"Other": "อื่น ๆ",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -404,6 +404,7 @@
 	"OpenAI Model": "OpenAI Model",
 	"OpenAI Token": "OpenAI Token",
 	"OpenAI URL": "OpenAI URL",
+	"Optimize prompt": "",
 	"Options": "Opsiýalar",
 	"Other": "Başga",
 	"Other Parameters": "Başga Parametrler",

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "",
+        "Optimize prompt": "",
 	"or": "",
 	"Organize your users": "",
 	"Other": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "OpenAI API Anahtarı gereklidir.",
 	"OpenAI API settings updated": "OpenAI API ayarları güncellendi",
 	"OpenAI URL/Key required.": "OpenAI URL/Anahtar gereklidir.",
+        "Optimize prompt": "",
 	"or": "veya",
 	"Organize your users": "Kullanıcılarınızı düzenleyin",
 	"Other": "Diğer",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Потрібен ключ OpenAI API.",
 	"OpenAI API settings updated": "Налаштування OpenAI API оновлено",
 	"OpenAI URL/Key required.": "Потрібен OpenAI URL/ключ.",
+        "Optimize prompt": "",
 	"or": "або",
 	"Organize your users": "Організуйте своїх користувачів",
 	"Other": "Інше",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "اوپن اے آئی API کلید درکار ہے",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "اوپن اے آئی یو آر ایل/کلید درکار ہے",
+        "Optimize prompt": "",
 	"or": "یا",
 	"Organize your users": "",
 	"Other": "دیگر",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "Bắt buộc nhập API OpenAI Key.",
 	"OpenAI API settings updated": "",
 	"OpenAI URL/Key required.": "Yêu cầu URL/Key API OpenAI.",
+        "Optimize prompt": "",
 	"or": "hoặc",
 	"Organize your users": "",
 	"Other": "Khác",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "需要 OpenAI API 密钥。",
 	"OpenAI API settings updated": "OpenAI API 设置已更新",
 	"OpenAI URL/Key required.": "需要 OpenAI URL/Key",
+        "Optimize prompt": "",
 	"or": "或",
 	"Organize your users": "组织用户",
 	"Other": "其他",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -789,6 +789,7 @@
 	"OpenAI API Key is required.": "需要 OpenAI API 金鑰。",
 	"OpenAI API settings updated": "OpenAI API 設定已更新",
 	"OpenAI URL/Key required.": "需要 OpenAI URL 或金鑰。",
+        "Optimize prompt": "",
 	"or": "或",
 	"Organize your users": "組織您的使用者",
 	"Other": "其他",


### PR DESCRIPTION
## Summary
- add `Optimize prompt` translation entry to en-US and en-GB locales
- add placeholder `Optimize prompt` key across remaining locales

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903683c8f4832f83a70dae5171d5d2