### PR TITLE
style: unify new button styles

### DIFF
--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -499,11 +499,11 @@ import Sparkles from '../icons/Sparkles.svelte';
 										filesInputElement.click();
 									}}
 								>
-									<button
-										class="bg-transparent hover:bg-white/80 text-gray-800 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5 outline-hidden focus:outline-hidden"
-										type="button"
-										aria-label="More"
-									>
+                                                                        <button
+                                                                                class="text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5"
+                                                                                type="button"
+                                                                                aria-label="More"
+                                                                        >
 										<svg
 											xmlns="http://www.w3.org/2000/svg"
 											viewBox="0 0 20 20"

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1109,11 +1109,11 @@
 												chatInput?.focus();
 											}}
 										>
-											<button
-												class="bg-transparent hover:bg-gray-100 text-gray-800 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5 outline-hidden focus:outline-hidden"
-												type="button"
-												aria-label="More"
-											>
+                                                                                        <button
+                                                                                                class="text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5"
+                                                                                                type="button"
+                                                                                                aria-label="More"
+                                                                                        >
 												<svg
 													xmlns="http://www.w3.org/2000/svg"
 													viewBox="0 0 20 20"


### PR DESCRIPTION
## Summary
- apply standard text-gray hover styles to the message input "More" buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npx eslint src/lib/components/channel/MessageInput.svelte src/lib/components/chat/MessageInput.svelte` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689039f405f0832fb4c204cd0f7368c7