### PR TITLE
Improve prompt optimizer error handling

### DIFF
--- a/src/lib/apis/promptOptimizer/index.ts
+++ b/src/lib/apis/promptOptimizer/index.ts
@@ -1,37 +1,29 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 export const optimizePrompt = async (token: string, prompt: string) => {
-        let error = null;
-
-        const res = await fetch(`${WEBUI_API_BASE_URL}/prompt-optimizer/optimize`, {
-                method: 'POST',
-                headers: {
-                        Accept: 'application/json',
-                        'Content-Type': 'application/json',
-                        authorization: `Bearer ${token}`
-                },
-                body: JSON.stringify({
-                        prompt: prompt
-                })
-        })
-                .then(async (res) => {
-                        if (!res.ok) throw await res.json();
-                        return res.json();
-                })
-                .catch((err) => {
-                        console.log(err);
-                        if ('detail' in err) {
-                                error = err.detail;
-                        } else {
-                                error = err;
-                        }
-                        return null;
+        try {
+                const res = await fetch(`${WEBUI_API_BASE_URL}/prompt-optimizer/optimize`, {
+                        method: 'POST',
+                        headers: {
+                                Accept: 'application/json',
+                                'Content-Type': 'application/json',
+                                authorization: `Bearer ${token}`
+                        },
+                        body: JSON.stringify({
+                                prompt: prompt
+                        })
                 });
 
-        if (error) {
+                if (!res.ok) {
+                        throw await res.json();
+                }
+
+                const data = await res.json();
+                return data?.optimized;
+        } catch (err: any) {
+                console.log(err);
+                const error = err?.detail ?? 'Prompt optimization failed';
                 throw error;
         }
-
-        return res?.optimized;
 };
 

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -26,10 +26,11 @@ import Sparkles from '../icons/Sparkles.svelte';
         
         export let id = null;
 
-	let draggedOver = false;
+        let draggedOver = false;
 
-	let recording = false;
-	let content = '';
+        let recording = false;
+        let optimizingPrompt = false;
+        let content = '';
 	let files = [];
 
 	let filesInputElement;
@@ -523,17 +524,22 @@ import Sparkles from '../icons/Sparkles.svelte';
                                                                         <button
                                                                                 class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
                                                                                 type="button"
+                                                                                disabled={optimizingPrompt}
                                                                                 on:click={async () => {
                                                                                         try {
+                                                                                                optimizingPrompt = true;
                                                                                                 content = await optimizePrompt(localStorage.token, content);
                                                                                         } catch (error) {
                                                                                                 console.error(error);
+                                                                                                toast.error(error);
+                                                                                        } finally {
+                                                                                                optimizingPrompt = false;
                                                                                         }
                                                                                 }}
                                                                         >
                                                                                 <Sparkles className="size-5" strokeWidth="1.75" />
                                                                         </button>
-                                                                </Tooltip>
+                                                               </Tooltip>
 
                                                                 {#if content === ''}
                                                                         <Tooltip content={$i18n.t('Record voice')}>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -88,8 +88,9 @@
 
 	let showToolServers = false;
 
-	let loaded = false;
-	let recording = false;
+        let loaded = false;
+        let recording = false;
+        let optimizingPrompt = false;
 
 	let isComposing = false;
 
@@ -1236,16 +1237,21 @@
                                                                                                   <button
                                                                                                           class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
                                                                                                           type="button"
+                                                                                                          disabled={optimizingPrompt}
                                                                                                           on:click={async () => {
                                                                                                                   try {
+                                                                                                                          optimizingPrompt = true;
                                                                                                                           prompt = await optimizePrompt(localStorage.token, prompt);
                                                                                                                   } catch (error) {
                                                                                                                           console.error(error);
+                                                                                                                          toast.error(error);
+                                                                                                                  } finally {
+                                                                                                                          optimizingPrompt = false;
                                                                                                                   }
                                                                                                           }}
                                                                                                   >
-                                                                                                          <Sparkles className="size-5" strokeWidth="1.75" />
-                                                                                                  </button>
+                                                                                                         <Sparkles className="size-5" strokeWidth="1.75" />
+                                                                                                 </button>
                                                                                           </Tooltip>
 
                                                                                           <Tooltip content={$i18n.t('Record voice')}>


### PR DESCRIPTION
## Summary
- refactor prompt optimizer API to use try/catch and surface backend error details
- show toast errors and disable "Optimize" buttons while requests are in flight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install vitest --no-save` *(fails: AggregateError [ENETUNREACH])* 
- `npm run lint:frontend` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6890e40d2274832f81fc86e7102411fb