### PR TITLE
feat: show spinner during prompt optimization

### DIFF
--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -17,6 +17,7 @@ import { uploadFile } from '$lib/apis/files';
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import FileItem from '../common/FileItem.svelte';
 import Image from '../common/Image.svelte';
+import Spinner from '../common/Spinner.svelte';
 import { transcribeAudio } from '$lib/apis/audio';
 import { optimizePrompt } from '$lib/apis';
 import FilesOverlay from '../chat/MessageInput/FilesOverlay.svelte';
@@ -520,26 +521,30 @@ import Sparkles from '../icons/Sparkles.svelte';
 							</div>
 
                                                         <div class="self-end flex space-x-1 mr-1">
-                                                                <Tooltip content={$i18n.t('Optimize prompt')}>
-                                                                        <button
-                                                                                class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
-                                                                                type="button"
-                                                                                disabled={optimizingPrompt}
-                                                                                on:click={async () => {
-                                                                                        try {
-                                                                                                optimizingPrompt = true;
-                                                                                                content = await optimizePrompt(localStorage.token, content);
-                                                                                        } catch (error) {
-                                                                                                console.error(error);
-                                                                                                toast.error(error);
-                                                                                        } finally {
-                                                                                                optimizingPrompt = false;
-                                                                                        }
-                                                                                }}
-                                                                        >
-                                                                                <Sparkles className="size-5" strokeWidth="1.75" />
-                                                                        </button>
-                                                               </Tooltip>
+                                                                  <Tooltip content={$i18n.t('Optimize prompt')}>
+                                                                          <button
+                                                                                  class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
+                                                                                  type="button"
+                                                                                  disabled={optimizingPrompt}
+                                                                                  on:click={async () => {
+                                                                                          try {
+                                                                                                  optimizingPrompt = true;
+                                                                                                  content = await optimizePrompt(localStorage.token, content);
+                                                                                          } catch (error) {
+                                                                                                  console.error(error);
+                                                                                                  toast.error(error);
+                                                                                          } finally {
+                                                                                                  optimizingPrompt = false;
+                                                                                          }
+                                                                                  }}
+                                                                          >
+                                                                                  {#if optimizingPrompt}
+                                                                                          <Spinner className="size-5" />
+                                                                                  {:else}
+                                                                                          <Sparkles className="size-5" strokeWidth="1.75" />
+                                                                                  {/if}
+                                                                          </button>
+                                                                  </Tooltip>
 
                                                                 {#if content === ''}
                                                                         <Tooltip content={$i18n.t('Record voice')}>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -36,8 +36,9 @@
 
 	import RichTextInput from '../common/RichTextInput.svelte';
 	import Tooltip from '../common/Tooltip.svelte';
-	import FileItem from '../common/FileItem.svelte';
-	import Image from '../common/Image.svelte';
+import FileItem from '../common/FileItem.svelte';
+import Image from '../common/Image.svelte';
+import Spinner from '../common/Spinner.svelte';
 
 	import XMark from '../icons/XMark.svelte';
 	import Headphone from '../icons/Headphone.svelte';
@@ -1250,7 +1251,11 @@
                                                                                                                   }
                                                                                                           }}
                                                                                                   >
-                                                                                                         <Sparkles className="size-5" strokeWidth="1.75" />
+                                                                                                         {#if optimizingPrompt}
+                                                                                                                 <Spinner className="size-5" />
+                                                                                                         {:else}
+                                                                                                                 <Sparkles className="size-5" strokeWidth="1.75" />
+                                                                                                         {/if}
                                                                                                  </button>
                                                                                           </Tooltip>
 


### PR DESCRIPTION
## Summary
- add loading spinner to chat and channel message inputs when optimizing a prompt
- keep optimize prompt button disabled until prompt optimization completes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install` *(fails: AggregateError [ENETUNREACH])* 
- `npm run lint:frontend` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6890ef414c24832f90cbdd99f4e567b7