### PR TITLE
feat: add tools dropdown

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -29,7 +29,8 @@
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
 
-	import InputMenu from './MessageInput/InputMenu.svelte';
+        import InputMenu from './MessageInput/InputMenu.svelte';
+        import ToolsMenu from './MessageInput/ToolsMenu.svelte';
 	import VoiceRecording from './MessageInput/VoiceRecording.svelte';
 	import FilesOverlay from './MessageInput/FilesOverlay.svelte';
 	import Commands from './MessageInput/Commands.svelte';
@@ -42,13 +43,11 @@ import Spinner from '../common/Spinner.svelte';
 
 	import XMark from '../icons/XMark.svelte';
 	import Headphone from '../icons/Headphone.svelte';
-	import GlobeAlt from '../icons/GlobeAlt.svelte';
-	import PhotoSolid from '../icons/PhotoSolid.svelte';
-	import Photo from '../icons/Photo.svelte';
-        import CommandLine from '../icons/CommandLine.svelte';
+        import Photo from '../icons/Photo.svelte';
+        import WrenchSolid from '../icons/WrenchSolid.svelte';
         import Sparkles from '../icons/Sparkles.svelte';
-	import { KokoroWorker } from '$lib/workers/KokoroWorker';
-	import ToolServersModal from './ToolServersModal.svelte';
+        import { KokoroWorker } from '$lib/workers/KokoroWorker';
+        import ToolServersModal from './ToolServersModal.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -1062,10 +1061,9 @@ import Spinner from '../common/Spinner.svelte';
 
 								<div class=" flex justify-between mt-1.5 mb-2.5 mx-0.5 max-w-full">
 									<div class="ml-1 self-end gap-0.5 flex items-center flex-1 max-w-[80%]">
-										<InputMenu
-											bind:selectedToolIds
-											{screenCaptureHandler}
-											{inputFilesHandler}
+                                                                                <InputMenu
+                                                                                        {screenCaptureHandler}
+                                                                                        {inputFilesHandler}
 											uploadFilesHandler={() => {
 												filesInputElement.click();
 											}}
@@ -1127,69 +1125,52 @@ import Spinner from '../common/Spinner.svelte';
 													/>
 												</svg>
 											</button>
-										</InputMenu>
+                                                                                </InputMenu>
 
-										<div class="flex gap-0.5 items-center overflow-x-auto scrollbar-none flex-1">
-											{#if $_user}
-												{#if $config?.features?.enable_web_search && ($_user.role === 'admin' || $_user?.permissions?.features?.web_search)}
-													<Tooltip content={$i18n.t('Search the internet')} placement="top">
-														<button
-															on:click|preventDefault={() => (webSearchEnabled = !webSearchEnabled)}
-															type="button"
-															class="px-1.5 @xl:px-2.5 py-1.5 flex gap-1.5 items-center text-sm rounded-full font-medium transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {webSearchEnabled ||
-															($settings?.webSearch ?? false) === 'always'
-																? 'bg-blue-100 dark:bg-blue-500/20 text-blue-500 dark:text-blue-400'
-																: 'bg-transparent text-gray-600 dark:text-gray-300 border-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}"
-														>
-															<GlobeAlt className="size-5" strokeWidth="1.75" />
-															<span
-																class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis translate-y-[0.5px] mr-0.5"
-																>{$i18n.t('Web Search')}</span
-															>
-														</button>
-													</Tooltip>
-												{/if}
+                                                                                <ToolsMenu
+                                                                                        bind:selectedToolIds
+                                                                                        bind:webSearchEnabled
+                                                                                        bind:codeInterpreterEnabled
+                                                                                        bind:imageGenerationEnabled
+                                                                                        onClose={async () => {
+                                                                                                await tick();
 
-												{#if $config?.features?.enable_image_generation && ($_user.role === 'admin' || $_user?.permissions?.features?.image_generation)}
-													<Tooltip content={$i18n.t('Generate an image')} placement="top">
-														<button
-															on:click|preventDefault={() =>
-																(imageGenerationEnabled = !imageGenerationEnabled)}
-															type="button"
-															class="px-1.5 @xl:px-2.5 py-1.5 flex gap-1.5 items-center text-sm rounded-full font-medium transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {imageGenerationEnabled
-																? 'bg-gray-100 dark:bg-gray-500/20 text-gray-600 dark:text-gray-400'
-																: 'bg-transparent text-gray-600 dark:text-gray-300 border-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 '}"
-														>
-															<Photo className="size-5" strokeWidth="1.75" />
-															<span
-																class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis translate-y-[0.5px] mr-0.5"
-																>{$i18n.t('Image')}</span
-															>
-														</button>
-													</Tooltip>
-												{/if}
+                                                                                                const chatInput = document.getElementById('chat-input');
+                                                                                                chatInput?.focus();
+                                                                                        }}
+                                                                                >
+                                                                                        <button
+                                                                                                class="text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5"
+                                                                                                type="button"
+                                                                                                aria-label="Tools"
+                                                                                        >
+                                                                                                <WrenchSolid className="size-5" />
+                                                                                        </button>
+                                                                                </ToolsMenu>
 
-												{#if $config?.features?.enable_code_interpreter && ($_user.role === 'admin' || $_user?.permissions?.features?.code_interpreter)}
-													<Tooltip content={$i18n.t('Execute code for analysis')} placement="top">
-														<button
-															on:click|preventDefault={() =>
-																(codeInterpreterEnabled = !codeInterpreterEnabled)}
-															type="button"
-															class="px-1.5 @xl:px-2.5 py-1.5 flex gap-1.5 items-center text-sm rounded-full font-medium transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {codeInterpreterEnabled
-																? 'bg-gray-100 dark:bg-gray-500/20 text-gray-600 dark:text-gray-400'
-																: 'bg-transparent text-gray-600 dark:text-gray-300 border-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 '}"
-														>
-															<CommandLine className="size-5" strokeWidth="1.75" />
-															<span
-																class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis translate-y-[0.5px] mr-0.5"
-																>{$i18n.t('Code Interpreter')}</span
-															>
-														</button>
-													</Tooltip>
-												{/if}
-											{/if}
-										</div>
-									</div>
+                                                                                <div class="flex gap-0.5 items-center overflow-x-auto scrollbar-none flex-1">
+                                                                                        {#if $_user}
+                                                                                                {#if $config?.features?.enable_image_generation && ($_user.role === 'admin' || $_user?.permissions?.features?.image_generation)}
+                                                                                                        <Tooltip content={$i18n.t('Generate an image')} placement="top">
+                                                                                                                <button
+                                                                                                                        on:click|preventDefault={() =>
+                                                                                                                               (imageGenerationEnabled = !imageGenerationEnabled)}
+                                                                                                                        type="button"
+                                                                                                                        class="px-1.5 @xl:px-2.5 py-1.5 flex gap-1.5 items-center text-sm rounded-full font-medium transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {imageGenerationEnabled
+                                                                                                                               ? 'bg-gray-100 dark:bg-gray-500/20 text-gray-600 dark:text-gray-400'
+                                                                                                                               : 'bg-transparent text-gray-600 dark:text-gray-300 border-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 '}"
+                                                                                                                >
+                                                                                                                        <Photo className="size-5" strokeWidth="1.75" />
+                                                                                                                        <span
+                                                                                                                               class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis translate-y-[0.5px] mr-0.5"
+                                                                                                                               >{$i18n.t('Image')}</span
+                                                                                                                        >
+                                                                                                                </button>
+                                                                                                        </Tooltip>
+                                                                                                {/if}
+                                                                                        {/if}
+                                                                               </div>
+                                                                       </div>
 
 									<div class="self-end flex space-x-1 mr-1 shrink-0">
 										{#if toolServers.length > 0}

--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -1,22 +1,14 @@
 <script lang="ts">
-	import { DropdownMenu } from 'bits-ui';
-	import { flyAndScale } from '$lib/utils/transitions';
-	import { getContext, onMount, tick } from 'svelte';
+        import { DropdownMenu } from 'bits-ui';
+        import { flyAndScale } from '$lib/utils/transitions';
+        import { getContext } from 'svelte';
 
-	import { config, user, tools as _tools, mobile } from '$lib/stores';
-	import { createPicker } from '$lib/utils/google-drive-picker';
+        import { config, user } from '$lib/stores';
 
-	import { getTools } from '$lib/apis/tools';
-
-	import Dropdown from '$lib/components/common/Dropdown.svelte';
-	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import DocumentArrowUpSolid from '$lib/components/icons/DocumentArrowUpSolid.svelte';
-	import Switch from '$lib/components/common/Switch.svelte';
-	import GlobeAltSolid from '$lib/components/icons/GlobeAltSolid.svelte';
-	import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
-	import CameraSolid from '$lib/components/icons/CameraSolid.svelte';
-	import PhotoSolid from '$lib/components/icons/PhotoSolid.svelte';
-	import CommandLineSolid from '$lib/components/icons/CommandLineSolid.svelte';
+        import Dropdown from '$lib/components/common/Dropdown.svelte';
+        import Tooltip from '$lib/components/common/Tooltip.svelte';
+        import DocumentArrowUpSolid from '$lib/components/icons/DocumentArrowUpSolid.svelte';
+        import CameraSolid from '$lib/components/icons/CameraSolid.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -24,37 +16,15 @@
 	export let uploadFilesHandler: Function;
 	export let inputFilesHandler: Function;
 
-	export let uploadGoogleDriveHandler: Function;
-	export let uploadOneDriveHandler: Function;
+        export let uploadGoogleDriveHandler: Function;
+        export let uploadOneDriveHandler: Function;
 
-	export let selectedToolIds: string[] = [];
+        export let onClose: Function;
 
-	export let onClose: Function;
+        let show = false;
 
-	let tools = {};
-	let show = false;
-
-	$: if (show) {
-		init();
-	}
-
-	let fileUploadEnabled = true;
-	$: fileUploadEnabled = $user.role === 'admin' || $user?.permissions?.chat?.file_upload;
-
-	const init = async () => {
-		if ($_tools === null) {
-			await _tools.set(await getTools(localStorage.token));
-		}
-
-		tools = $_tools.reduce((a, tool, i, arr) => {
-			a[tool.id] = {
-				name: tool.name,
-				description: tool.meta.description,
-				enabled: selectedToolIds.includes(tool.id)
-			};
-			return a;
-		}, {});
-	};
+        let fileUploadEnabled = true;
+        $: fileUploadEnabled = $user.role === 'admin' || $user?.permissions?.chat?.file_upload;
 
 	const detectMobile = () => {
 		const userAgent = navigator.userAgent || navigator.vendor || window.opera;
@@ -101,49 +71,6 @@
 			align="start"
 			transition={flyAndScale}
 		>
-			{#if Object.keys(tools).length > 0}
-				<div class="  max-h-28 overflow-y-auto scrollbar-hidden">
-					{#each Object.keys(tools) as toolId}
-						<button
-							class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
-							on:click={() => {
-								tools[toolId].enabled = !tools[toolId].enabled;
-							}}
-						>
-							<div class="flex-1 truncate">
-								<Tooltip
-									content={tools[toolId]?.description ?? ''}
-									placement="top-start"
-									className="flex flex-1 gap-2 items-center"
-								>
-									<div class="shrink-0">
-										<WrenchSolid />
-									</div>
-
-									<div class=" truncate">{tools[toolId].name}</div>
-								</Tooltip>
-							</div>
-
-							<div class=" shrink-0">
-								<Switch
-									state={tools[toolId].enabled}
-									on:change={async (e) => {
-										const state = e.detail;
-										await tick();
-										if (state) {
-											selectedToolIds = [...selectedToolIds, toolId];
-										} else {
-											selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
-										}
-									}}
-								/>
-							</div>
-						</button>
-					{/each}
-				</div>
-
-				<hr class="border-black/5 dark:border-white/5 my-1" />
-			{/if}
 
 			<Tooltip
 				content={!fileUploadEnabled ? $i18n.t('You do not have permission to upload files') : ''}

--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+    import { DropdownMenu } from 'bits-ui';
+    import { flyAndScale } from '$lib/utils/transitions';
+    import { getContext, tick } from 'svelte';
+
+    import { config, user, tools as _tools } from '$lib/stores';
+    import { getTools } from '$lib/apis/tools';
+
+    import Dropdown from '$lib/components/common/Dropdown.svelte';
+    import Tooltip from '$lib/components/common/Tooltip.svelte';
+    import Switch from '$lib/components/common/Switch.svelte';
+
+    import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
+    import GlobeAltSolid from '$lib/components/icons/GlobeAltSolid.svelte';
+    import CommandLineSolid from '$lib/components/icons/CommandLineSolid.svelte';
+    import PhotoSolid from '$lib/components/icons/PhotoSolid.svelte';
+
+    const i18n = getContext('i18n');
+
+    export let selectedToolIds: string[] = [];
+    export let webSearchEnabled = false;
+    export let codeInterpreterEnabled = false;
+    export let imageGenerationEnabled = false;
+
+    export let onClose: Function;
+
+    let show = false;
+    let tools = {};
+
+    $: if (show) {
+        init();
+    }
+
+    const init = async () => {
+        if ($_tools === null) {
+            await _tools.set(await getTools(localStorage.token));
+        }
+
+        tools = $_tools.reduce((a, tool) => {
+            a[tool.id] = {
+                name: tool.name,
+                description: tool.meta.description,
+                enabled: selectedToolIds.includes(tool.id)
+            };
+            return a;
+        }, {});
+    };
+</script>
+
+<Dropdown
+    bind:show
+    on:change={(e) => {
+        if (e.detail === false) {
+            onClose?.();
+        }
+    }}
+>
+    <Tooltip content={$i18n.t('Tools')}>
+        <slot />
+    </Tooltip>
+
+    <div slot="content">
+        <DropdownMenu.Content
+            class="w-full max-w-[200px] rounded-xl px-1 py-1 border border-gray-300/30 dark:border-gray-700/50 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-sm"
+            sideOffset={10}
+            alignOffset={-8}
+            side="top"
+            align="start"
+            transition={flyAndScale}
+        >
+            {#if Object.keys(tools).length > 0}
+                <div class="max-h-28 overflow-y-auto scrollbar-hidden">
+                    {#each Object.keys(tools) as toolId}
+                        <button
+                            class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
+                            on:click={() => {
+                                tools[toolId].enabled = !tools[toolId].enabled;
+                            }}
+                        >
+                            <div class="flex-1 truncate">
+                                <Tooltip
+                                    content={tools[toolId]?.description ?? ''}
+                                    placement="top-start"
+                                    className="flex flex-1 gap-2 items-center"
+                                >
+                                    <div class="shrink-0">
+                                        <WrenchSolid />
+                                    </div>
+                                    <div class="truncate">{tools[toolId].name}</div>
+                                </Tooltip>
+                            </div>
+
+                            <div class="shrink-0">
+                                <Switch
+                                    state={tools[toolId].enabled}
+                                    on:change={async (e) => {
+                                        const state = e.detail;
+                                        await tick();
+                                        if (state) {
+                                            selectedToolIds = [...selectedToolIds, toolId];
+                                        } else {
+                                            selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
+                                        }
+                                    }}
+                                />
+                            </div>
+                        </button>
+                    {/each}
+                </div>
+                <hr class="border-black/5 dark:border-white/5 my-1" />
+            {/if}
+
+            {#if $config?.features?.enable_web_search && ($user.role === 'admin' || $user?.permissions?.features?.web_search)}
+                <button
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
+                    on:click={() => (webSearchEnabled = !webSearchEnabled)}
+                >
+                    <div class="flex gap-2 items-center">
+                        <GlobeAltSolid />
+                        <div>{$i18n.t('Web Search')}</div>
+                    </div>
+                    <div class="shrink-0">
+                        <Switch state={webSearchEnabled} on:change={(e) => (webSearchEnabled = e.detail)} />
+                    </div>
+                </button>
+            {/if}
+
+            {#if $config?.features?.enable_code_interpreter && ($user.role === 'admin' || $user?.permissions?.features?.code_interpreter)}
+                <button
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
+                    on:click={() => (codeInterpreterEnabled = !codeInterpreterEnabled)}
+                >
+                    <div class="flex gap-2 items-center">
+                        <CommandLineSolid />
+                        <div>{$i18n.t('Code Interpreter')}</div>
+                    </div>
+                    <div class="shrink-0">
+                        <Switch state={codeInterpreterEnabled} on:change={(e) => (codeInterpreterEnabled = e.detail)} />
+                    </div>
+                </button>
+            {/if}
+
+            {#if $config?.features?.enable_image_generation && ($user.role === 'admin' || $user?.permissions?.features?.image_generation)}
+                <button
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
+                    on:click={() => (imageGenerationEnabled = !imageGenerationEnabled)}
+                >
+                    <div class="flex gap-2 items-center">
+                        <PhotoSolid />
+                        <div>{$i18n.t('Image')}</div>
+                    </div>
+                    <div class="shrink-0">
+                        <Switch state={imageGenerationEnabled} on:change={(e) => (imageGenerationEnabled = e.detail)} />
+                    </div>
+                </button>
+            {/if}
+        </DropdownMenu.Content>
+    </div>
+</Dropdown>
+

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -718,5 +718,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Tools": ""
 }


### PR DESCRIPTION
## Summary
- add dedicated ToolsMenu for selecting tools and built-in features
- integrate Tools menu in message input and streamline InputMenu
- add missing "Tools" locale entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689125b16b40832fa50c8e420c56b079