### PR TITLE
Refactor tools menu toggling

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,13 +46,14 @@
 		"sass-embedded": "^1.81.0",
 		"svelte": "^4.2.17",
 		"svelte-check": "^3.8.5",
-		"svelte-confetti": "^1.3.2",
-		"tailwindcss": "^4.0.0",
-		"tslib": "^2.4.1",
-		"typescript": "^5.5.4",
-		"vite": "^5.4.19",
-		"vitest": "^1.6.1"
-	},
+                "svelte-confetti": "^1.3.2",
+                "tailwindcss": "^4.0.0",
+                "tslib": "^2.4.1",
+                "typescript": "^5.5.4",
+                "vite": "^5.4.19",
+                "vitest": "^1.6.1",
+                "@testing-library/svelte": "^5.2.8"
+        },
 	"type": "module",
 	"dependencies": {
 		"@azure/msal-browser": "^4.5.0",

--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -8,12 +8,12 @@
 
     import Dropdown from '$lib/components/common/Dropdown.svelte';
     import Tooltip from '$lib/components/common/Tooltip.svelte';
-    import Switch from '$lib/components/common/Switch.svelte';
 
     import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
     import GlobeAltSolid from '$lib/components/icons/GlobeAltSolid.svelte';
     import CommandLineSolid from '$lib/components/icons/CommandLineSolid.svelte';
     import PhotoSolid from '$lib/components/icons/PhotoSolid.svelte';
+    import Check from '$lib/components/icons/Check.svelte';
 
     const i18n = getContext('i18n');
 
@@ -71,88 +71,90 @@
             {#if Object.keys(tools).length > 0}
                 <div class="max-h-28 overflow-y-auto scrollbar-hidden">
                     {#each Object.keys(tools) as toolId}
-                        <button
-                            class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
-                            on:click={() => {
+                        <DropdownMenu.Item
+                            class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                            on:select={async (e) => {
+                                e.preventDefault();
                                 tools[toolId].enabled = !tools[toolId].enabled;
+                                await tick();
+                                if (tools[toolId].enabled) {
+                                    selectedToolIds = [...selectedToolIds, toolId];
+                                } else {
+                                    selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
+                                }
                             }}
                         >
-                            <div class="flex-1 truncate">
-                                <Tooltip
-                                    content={tools[toolId]?.description ?? ''}
-                                    placement="top-start"
-                                    className="flex flex-1 gap-2 items-center"
-                                >
-                                    <div class="shrink-0">
-                                        <WrenchSolid />
-                                    </div>
-                                    <div class="truncate">{tools[toolId].name}</div>
-                                </Tooltip>
-                            </div>
-
-                            <div class="shrink-0">
-                                <Switch
-                                    state={tools[toolId].enabled}
-                                    on:change={async (e) => {
-                                        const state = e.detail;
-                                        await tick();
-                                        if (state) {
-                                            selectedToolIds = [...selectedToolIds, toolId];
-                                        } else {
-                                            selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
-                                        }
-                                    }}
-                                />
-                            </div>
-                        </button>
+                            <Tooltip
+                                content={tools[toolId]?.description ?? ''}
+                                placement="top-start"
+                                className="flex flex-1 gap-2 items-center truncate"
+                            >
+                                <div class="shrink-0">
+                                    <WrenchSolid />
+                                </div>
+                                <div class="truncate">{tools[toolId].name}</div>
+                            </Tooltip>
+                            {#if tools[toolId].enabled}
+                                <Check className="shrink-0" />
+                            {/if}
+                        </DropdownMenu.Item>
                     {/each}
                 </div>
                 <hr class="border-black/5 dark:border-white/5 my-1" />
             {/if}
 
             {#if $config?.features?.enable_web_search && ($user.role === 'admin' || $user?.permissions?.features?.web_search)}
-                <button
-                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
-                    on:click={() => (webSearchEnabled = !webSearchEnabled)}
+                <DropdownMenu.Item
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                    on:select={(e) => {
+                        e.preventDefault();
+                        webSearchEnabled = !webSearchEnabled;
+                    }}
                 >
                     <div class="flex gap-2 items-center">
                         <GlobeAltSolid />
                         <div>{$i18n.t('Web Search')}</div>
                     </div>
-                    <div class="shrink-0">
-                        <Switch state={webSearchEnabled} on:change={(e) => (webSearchEnabled = e.detail)} />
-                    </div>
-                </button>
+                    {#if webSearchEnabled}
+                        <Check className="shrink-0" />
+                    {/if}
+                </DropdownMenu.Item>
             {/if}
 
             {#if $config?.features?.enable_code_interpreter && ($user.role === 'admin' || $user?.permissions?.features?.code_interpreter)}
-                <button
-                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
-                    on:click={() => (codeInterpreterEnabled = !codeInterpreterEnabled)}
+                <DropdownMenu.Item
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                    on:select={(e) => {
+                        e.preventDefault();
+                        codeInterpreterEnabled = !codeInterpreterEnabled;
+                    }}
                 >
                     <div class="flex gap-2 items-center">
                         <CommandLineSolid />
                         <div>{$i18n.t('Code Interpreter')}</div>
                     </div>
-                    <div class="shrink-0">
-                        <Switch state={codeInterpreterEnabled} on:change={(e) => (codeInterpreterEnabled = e.detail)} />
-                    </div>
-                </button>
+                    {#if codeInterpreterEnabled}
+                        <Check className="shrink-0" />
+                    {/if}
+                </DropdownMenu.Item>
             {/if}
 
             {#if $config?.features?.enable_image_generation && ($user.role === 'admin' || $user?.permissions?.features?.image_generation)}
-                <button
-                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
-                    on:click={() => (imageGenerationEnabled = !imageGenerationEnabled)}
+                <DropdownMenu.Item
+                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                    on:select={(e) => {
+                        e.preventDefault();
+                        imageGenerationEnabled = !imageGenerationEnabled;
+                    }}
                 >
                     <div class="flex gap-2 items-center">
                         <PhotoSolid />
                         <div>{$i18n.t('Image')}</div>
                     </div>
-                    <div class="shrink-0">
-                        <Switch state={imageGenerationEnabled} on:change={(e) => (imageGenerationEnabled = e.detail)} />
-                    </div>
-                </button>
+                    {#if imageGenerationEnabled}
+                        <Check className="shrink-0" />
+                    {/if}
+                </DropdownMenu.Item>
             {/if}
         </DropdownMenu.Content>
     </div>

--- a/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
@@ -1,0 +1,41 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { setContext, tick } from 'svelte';
+import ToolsMenu from './ToolsMenu.svelte';
+import { config, user, tools as toolsStore } from '$lib/stores';
+
+describe('ToolsMenu', () => {
+    beforeEach(() => {
+        setContext('i18n', { t: (s: string) => s });
+        config.set({
+            features: {
+                enable_web_search: true,
+                enable_code_interpreter: true,
+                enable_image_generation: true
+            }
+        } as any);
+        user.set({ role: 'admin', permissions: { features: { web_search: true, code_interpreter: true, image_generation: true } } } as any);
+        toolsStore.set([{ id: 'test-tool', name: 'Test Tool', meta: { description: 'desc' } }]);
+    });
+
+    test('toggles selections via item click', async () => {
+        const { getByText, component } = render(ToolsMenu, {
+            props: {
+                selectedToolIds: [],
+                webSearchEnabled: false,
+                codeInterpreterEnabled: false,
+                imageGenerationEnabled: false,
+                onClose: () => {}
+            },
+            slots: { default: '<button>open</button>' }
+        });
+
+        await fireEvent.click(getByText('open'));
+        await tick();
+        await fireEvent.click(getByText('Web Search'));
+        expect(component.$$.ctx[component.$$.props['webSearchEnabled']]).toBe(true);
+
+        await fireEvent.click(getByText('Test Tool'));
+        const selectedToolIds = component.$$.ctx[component.$$.props['selectedToolIds']];
+        expect(selectedToolIds).toContain('test-tool');
+    });
+});


### PR DESCRIPTION
## Summary
- Replace toggle switches with dropdown menu items and checkmarks for tools and optional features
- Add unit test ensuring tools and features toggle on menu item clicks
- Include testing library dependency for front-end tests

## Testing
- `npm run test:frontend` *(fails: vitest not found, dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6891392bc018832face7136b6c422fe8