### PR TITLE
chore: guard user lookups

### DIFF
--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -83,15 +83,20 @@ class FeedbackUserResponse(FeedbackResponse):
 @router.get("/feedbacks/all", response_model=list[FeedbackUserResponse])
 async def get_all_feedbacks(user=Depends(get_admin_user)):
     feedbacks = Feedbacks.get_all_feedbacks()
-    return [
-        FeedbackUserResponse(
-            **feedback.model_dump(),
-            user=FeedbackUserReponse(
-                **Users.get_user_by_id(feedback.user_id).model_dump()
-            ),
+    responses: list[FeedbackUserResponse] = []
+    for feedback in feedbacks:
+        feedback_user = Users.get_user_by_id(feedback.user_id)
+        if not feedback_user:
+            continue
+
+        responses.append(
+            FeedbackUserResponse(
+                **feedback.model_dump(),
+                user=FeedbackUserReponse(**feedback_user.model_dump()),
+            )
         )
-        for feedback in feedbacks
-    ]
+
+    return responses
 
 
 @router.delete("/feedbacks/all")


### PR DESCRIPTION
## Summary
- avoid attribute errors if feedback user lookup fails
- validate channel user retrieval before calling `.model_dump`

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test` *(fails: sqlite3.OperationalError: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68913e0ae1f8832fbea2e0a91a197adc