### PR TITLE
Rename export feedback handler

### DIFF
--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -106,7 +106,7 @@ async def delete_all_feedbacks(user=Depends(get_admin_user)):
 
 
 @router.get("/feedbacks/all/export", response_model=list[FeedbackModel])
-async def get_all_feedbacks(user=Depends(get_admin_user)):
+async def export_all_feedbacks(user=Depends(get_admin_user)):
     feedbacks = Feedbacks.get_all_feedbacks()
     return [
         FeedbackModel(


### PR DESCRIPTION
## Summary
- rename `/feedbacks/all/export` handler to `export_all_feedbacks`

## Testing
- `ALLOWED_MODULES_FILE=/tmp/allowed_modules.json PYTHONPATH=backend python - <<'PY'
from open_webui.routers import evaluations
print([(r.path, r.endpoint.__name__) for r in evaluations.router.routes if 'feedbacks/all' in r.path])
PY`
- `PYTHONPATH=backend pytest backend/open_webui/test` *(fails: sqlite3.OperationalError: no such table: config; ModuleNotFoundError: No module named 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_6891423ece3c832fb2787f83b6c4dde5