### PR TITLE
refactor: rename feedback user response model

### DIFF
--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -65,7 +65,7 @@ async def update_config(
     }
 
 
-class FeedbackUserReponse(BaseModel):
+class FeedbackUserResponseData(BaseModel):
     id: str
     name: str
     email: str
@@ -77,7 +77,7 @@ class FeedbackUserReponse(BaseModel):
 
 
 class FeedbackUserResponse(FeedbackResponse):
-    user: Optional[FeedbackUserReponse] = None
+    user: Optional[FeedbackUserResponseData] = None
 
 
 @router.get("/feedbacks/all", response_model=list[FeedbackUserResponse])
@@ -92,7 +92,7 @@ async def get_all_feedbacks(user=Depends(get_admin_user)):
         responses.append(
             FeedbackUserResponse(
                 **feedback.model_dump(),
-                user=FeedbackUserReponse(**feedback_user.model_dump()),
+                user=FeedbackUserResponseData(**feedback_user.model_dump()),
             )
         )
 


### PR DESCRIPTION
## Summary
- rename `FeedbackUserReponse` to `FeedbackUserResponseData`
- update `FeedbackUserResponse` to use new user data model

## Testing
- `PYTHONPATH=backend:backend/open_webui pytest backend/open_webui/test/apps/webui/routers/test_models.py` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_689145a491bc832f90bc17e32a00e8e9