### PR TITLE
style: specify check icon size and stroke

### DIFF
--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -95,7 +95,7 @@
                                 <div class="truncate">{tools[toolId].name}</div>
                             </Tooltip>
                             {#if tools[toolId].enabled}
-                                <Check className="shrink-0" />
+                                <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
                             {/if}
                         </DropdownMenu.Item>
                     {/each}
@@ -116,7 +116,7 @@
                         <div>{$i18n.t('Web Search')}</div>
                     </div>
                     {#if webSearchEnabled}
-                        <Check className="shrink-0" />
+                        <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
                     {/if}
                 </DropdownMenu.Item>
             {/if}
@@ -134,7 +134,7 @@
                         <div>{$i18n.t('Code Interpreter')}</div>
                     </div>
                     {#if codeInterpreterEnabled}
-                        <Check className="shrink-0" />
+                        <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
                     {/if}
                 </DropdownMenu.Item>
             {/if}
@@ -152,7 +152,7 @@
                         <div>{$i18n.t('Image')}</div>
                     </div>
                     {#if imageGenerationEnabled}
-                        <Check className="shrink-0" />
+                        <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
                     {/if}
                 </DropdownMenu.Item>
             {/if}

--- a/src/lib/components/icons/Check.svelte
+++ b/src/lib/components/icons/Check.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	export let className = 'w-4 h-4';
-	export let strokeWidth = '1.5';
+        export let className = 'shrink-0 size-4 text-gray-900 dark:text-white';
+        export let strokeWidth = '2.5';
 </script>
 
 <svg


### PR DESCRIPTION
## Summary
- use explicit size and stroke weight for Tools menu check icons
- align default Check icon styling with app icon conventions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:frontend` (fails: vitest: not found)
- `npm install` (fails: ENETUNREACH when installing onnxruntime-node)


------
https://chatgpt.com/codex/tasks/task_e_689145f65dbc832f8d30c71d266acba5