### PR TITLE
feat: show security modal once per day

### DIFF
--- a/src/lib/components/SecurityModal.svelte
+++ b/src/lib/components/SecurityModal.svelte
@@ -30,10 +30,11 @@
 			</div>
 			<button
 				class="self-center"
-				on:click={() => {
-					localStorage.version = $config.version;
-					show = false;
-				}}
+                                on:click={() => {
+                                        localStorage.version = $config.version;
+                                        localStorage.securityMdShownDate = new Date().toISOString().slice(0, 10);
+                                        show = false;
+                                }}
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -77,10 +78,11 @@
 		</div>
 		<div class="flex justify-end pt-3 text-sm font-medium">
 			<button
-				on:click={() => {
-					localStorage.version = $config.version;
-					show = false;
-				}}
+                                on:click={() => {
+                                        localStorage.version = $config.version;
+                                        localStorage.securityMdShownDate = new Date().toISOString().slice(0, 10);
+                                        show = false;
+                                }}
 				class=" px-4 py-2 bg-emerald-700 hover:bg-emerald-800 text-gray-100 transition rounded-lg"
 			>
 				<span class="relative">{$i18n.t("Continue")}</span>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -193,9 +193,14 @@
 				}
 			});
                         
-			if ($user.role === 'admin' || $user.role === 'user'  ) {
-			        showSecuritymd.set(true)
-		        }	        
+                        if ($user.role === 'admin' || $user.role === 'user') {
+                                const lastShown = localStorage.getItem('securityMdShownDate');
+                                const today = new Date().toISOString().slice(0, 10);
+
+                                if (lastShown !== today) {
+                                        showSecuritymd.set(true);
+                                }
+                        }
                          
 			if ($page.url.searchParams.get('temporary-chat') === 'true') {
 				temporaryChatEnabled.set(true);


### PR DESCRIPTION
## Summary
- only show the security modal when the user hasn’t seen it today
- record the dismissal date when the security modal is closed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68915ea4f674832f8ed0f80f5e07c04b