### PR TITLE
Centralize security modal date handling

### DIFF
--- a/src/lib/components/SecurityModal.svelte
+++ b/src/lib/components/SecurityModal.svelte
@@ -5,7 +5,8 @@
 	import { WEBUI_NAME, config } from '$lib/stores';
 
 	import { WEBUI_VERSION } from '$lib/constants';
-	import { getSecuritymd } from '$lib/apis';
+        import { getSecuritymd } from '$lib/apis';
+        import { getTodayDate } from '$lib/utils/date';
 
 	import Modal from './common/Modal.svelte';
 
@@ -17,7 +18,7 @@
 
         function markShown() {
                 localStorage.version = $config.version;
-                localStorage.securityMdShownDate = new Date().toISOString().slice(0, 10);
+                localStorage.securityMdShownDate = getTodayDate();
         }
 
         onMount(async () => {

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,0 +1,1 @@
+export const getTodayDate = () => new Date().toISOString().slice(0, 10);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -19,8 +19,9 @@
 	import { getBanners } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
 
-	import { WEBUI_VERSION } from '$lib/constants';
-	import { compareVersion } from '$lib/utils';
+        import { WEBUI_VERSION } from '$lib/constants';
+        import { compareVersion } from '$lib/utils';
+        import { getTodayDate } from '$lib/utils/date';
 
 	import {
 		config,
@@ -195,7 +196,7 @@
                         
                         if ($user.role === 'admin' || $user.role === 'user') {
                                 const lastShown = localStorage.getItem('securityMdShownDate');
-                                const today = new Date().toISOString().slice(0, 10);
+                                const today = getTodayDate();
 
                                 if (lastShown !== today) {
                                         showSecuritymd.set(true);


### PR DESCRIPTION
## Summary
- add reusable `getTodayDate` helper for ISO date formatting
- use the helper in security modal and layout to track when security policy was shown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint config and dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891656e2f18832fa72a8e3ba47b9666