### PR TITLE
feat: organize custom tools into submenu

### DIFF
--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -69,37 +69,53 @@
             transition={flyAndScale}
         >
             {#if Object.keys(tools).length > 0}
-                <div class="max-h-28 overflow-y-auto scrollbar-hidden">
-                    {#each Object.keys(tools) as toolId}
-                        <DropdownMenu.Item
-                            class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
-                            on:click={async (e) => {
-                                e.preventDefault();
-                                tools[toolId].enabled = !tools[toolId].enabled;
-                                await tick();
-                                if (tools[toolId].enabled) {
-                                    selectedToolIds = [...selectedToolIds, toolId];
-                                } else {
-                                    selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
-                                }
-                            }}
-                        >
-                            <Tooltip
-                                content={tools[toolId]?.description ?? ''}
-                                placement="top-start"
-                                className="flex flex-1 gap-2 items-center truncate"
-                            >
-                                <div class="shrink-0">
-                                    <WrenchSolid />
-                                </div>
-                                <div class="truncate">{tools[toolId].name}</div>
-                            </Tooltip>
-                            {#if tools[toolId].enabled}
-                                <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
-                            {/if}
-                        </DropdownMenu.Item>
-                    {/each}
-                </div>
+                <DropdownMenu.Sub>
+                    <DropdownMenu.SubTrigger
+                        class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                    >
+                        <div class="flex gap-2 items-center">
+                            <WrenchSolid />
+                            <div>{$i18n.t('Tools')}</div>
+                        </div>
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.SubContent
+                        class="w-full max-w-[200px] rounded-xl px-1 py-1 border border-gray-300/30 dark:border-gray-700/50 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-sm"
+                        transition={flyAndScale}
+                        sideOffset={8}
+                    >
+                        <div class="max-h-28 overflow-y-auto scrollbar-hidden">
+                            {#each Object.keys(tools) as toolId}
+                                <DropdownMenu.Item
+                                    class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                                    on:click={async (e) => {
+                                        e.preventDefault();
+                                        tools[toolId].enabled = !tools[toolId].enabled;
+                                        await tick();
+                                        if (tools[toolId].enabled) {
+                                            selectedToolIds = [...selectedToolIds, toolId];
+                                        } else {
+                                            selectedToolIds = selectedToolIds.filter((id) => id !== toolId);
+                                        }
+                                    }}
+                                >
+                                    <Tooltip
+                                        content={tools[toolId]?.description ?? ''}
+                                        placement="top-start"
+                                        className="flex flex-1 gap-2 items-center truncate"
+                                    >
+                                        <div class="shrink-0">
+                                            <WrenchSolid />
+                                        </div>
+                                        <div class="truncate">{tools[toolId].name}</div>
+                                    </Tooltip>
+                                    {#if tools[toolId].enabled}
+                                        <Check className="shrink-0 size-4 text-gray-900 dark:text-white" strokeWidth="2.5" />
+                                    {/if}
+                                </DropdownMenu.Item>
+                            {/each}
+                        </div>
+                    </DropdownMenu.SubContent>
+                </DropdownMenu.Sub>
                 <hr class="border-black/5 dark:border-white/5 my-1" />
             {/if}
 

--- a/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
@@ -1,11 +1,11 @@
 import { render, fireEvent } from '@testing-library/svelte';
-import { setContext, tick } from 'svelte';
-import ToolsMenu from './ToolsMenu.svelte';
+import { tick } from 'svelte';
+import { describe, test, expect, beforeEach } from 'vitest';
+import ToolsMenu from './ToolsMenuTestWrapper.svelte';
 import { config, user, tools as toolsStore } from '$lib/stores';
 
 describe('ToolsMenu', () => {
     beforeEach(() => {
-        setContext('i18n', { t: (s: string) => s });
         config.set({
             features: {
                 enable_web_search: true,
@@ -26,7 +26,17 @@ describe('ToolsMenu', () => {
                 imageGenerationEnabled: false,
                 onClose: () => {}
             },
-            slots: { default: '<button>open</button>' }
+            context: new Map([
+                [
+                    'i18n',
+                    {
+                        subscribe: (run: Function) => {
+                            run({ t: (s: string) => s });
+                            return () => {};
+                        }
+                    }
+                ]
+            ])
         });
 
         await fireEvent.click(getByText('open'));
@@ -38,6 +48,8 @@ describe('ToolsMenu', () => {
         await fireEvent.click(getByText('open'));
         await tick();
 
+        await fireEvent.click(getByText('Tools'));
+        await tick();
         await fireEvent.click(getByText('Test Tool'));
         const selectedToolIds = component.$$.ctx[component.$$.props['selectedToolIds']];
         expect(selectedToolIds).toContain('test-tool');

--- a/src/lib/components/chat/MessageInput/ToolsMenuTestWrapper.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenuTestWrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import ToolsMenu from './ToolsMenu.svelte';
+  export let selectedToolIds: string[] = [];
+  export let webSearchEnabled = false;
+  export let codeInterpreterEnabled = false;
+  export let imageGenerationEnabled = false;
+  export let onClose: Function = () => {};
+</script>
+
+<ToolsMenu
+  bind:selectedToolIds
+  bind:webSearchEnabled
+  bind:codeInterpreterEnabled
+  bind:imageGenerationEnabled
+  {onClose}
+>
+  <button>open</button>
+</ToolsMenu>


### PR DESCRIPTION
## Summary
- group custom tools under a Tools submenu
- adjust ToolsMenu test to interact with Tools submenu
- add wrapper component for test slot rendering

## Testing
- `npx vitest run src/lib/components/chat/MessageInput/ToolsMenu.test.ts --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_6891648d6ab8832f83fb7d2af3883d0f