### PR TITLE
feat: track security policy display

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -38,6 +38,7 @@ class User(Base):
 
 class UserSettings(BaseModel):
     ui: Optional[dict] = {}
+    security_md_last_shown: Optional[str] = None
     model_config = ConfigDict(extra="allow")
     pass
 

--- a/src/lib/components/SecurityModal.svelte
+++ b/src/lib/components/SecurityModal.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { onMount, getContext } from 'svelte';
-	import { Confetti } from 'svelte-confetti';
+        import { onMount, getContext, createEventDispatcher } from 'svelte';
+        import { Confetti } from 'svelte-confetti';
 
-	import { WEBUI_NAME, config } from '$lib/stores';
+        import { WEBUI_NAME } from '$lib/stores';
 
-	import { WEBUI_VERSION } from '$lib/constants';
+        import { WEBUI_VERSION } from '$lib/constants';
         import { getSecuritymd } from '$lib/apis';
-        import { getTodayDate } from '$lib/utils/date';
 
 	import Modal from './common/Modal.svelte';
 
@@ -15,19 +14,10 @@
         export let show = false;
 
         let securitymd = null;
+        const dispatch = createEventDispatcher();
 
         function markShown() {
-                try {
-                        localStorage.version = $config.version;
-                        localStorage.securityMdShownDate = getTodayDate();
-                } catch (error) {
-                        console.error('Unable to access localStorage', error);
-                        try {
-                                sessionStorage.setItem('securityMdShownDate', getTodayDate());
-                        } catch {
-                                /* ignore */
-                        }
-                }
+                dispatch('dismiss');
         }
 
         onMount(async () => {


### PR DESCRIPTION
## Summary
- store `security_md_last_shown` in backend user settings
- show security policy modal only once per day using user settings
- update security modal to notify parent when dismissed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:frontend` (fails: vitest not found)
- `npm run lint` (fails: ESLint config not found)


------
https://chatgpt.com/codex/tasks/task_e_6891719b0a5c832fa4a28b833e0fa497