### PR TITLE
feat: attempt silent OAuth login for configured providers

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -161,8 +161,12 @@ Modification Log:
                 }
                 await checkOauthCallback();
 
-                const provider = Object.keys($config?.oauth?.providers ?? {})[0];
-                if (provider) {
+                const providerParam = querystringValue('provider');
+                const providers = providerParam
+                        ? [providerParam]
+                        : Object.keys($config?.oauth?.providers ?? {});
+
+                for (const provider of providers) {
                         try {
                                 const resp = await fetch(
                                         `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,


### PR DESCRIPTION
## Summary
- Attempt silent OAuth login for all configured providers or one selected via the `provider` query parameter

## Testing
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install` *(fails: ENETUNREACH during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_6891759a96e0832f9b94c830800f536e