### PR TITLE
Use user-specific default collection for file processing

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1077,7 +1077,7 @@ def process_file(
         collection_name = form_data.collection_name
 
         if collection_name is None:
-            collection_name = f"file-{file.id}"
+            collection_name = f"user-{user.id}"
 
         if form_data.content:
             # Update the content in the file
@@ -1085,7 +1085,7 @@ def process_file(
 
             try:
                 # /files/{file_id}/data/content/update
-                VECTOR_DB_CLIENT.delete_collection(collection_name=f"file-{file.id}")
+                VECTOR_DB_CLIENT.delete_collection(collection_name=f"user-{user.id}")
             except:
                 # Audio file upload pipeline
                 pass
@@ -1109,7 +1109,7 @@ def process_file(
             # Usage: /knowledge/{id}/file/add, /knowledge/{id}/file/update
 
             result = VECTOR_DB_CLIENT.query(
-                collection_name=f"file-{file.id}", filter={"file_id": file.id}
+                collection_name=f"user-{user.id}", filter={"file_id": file.id}
             )
 
             if result is not None and len(result.ids[0]) > 0:


### PR DESCRIPTION
## Summary
- default retrieval collections to the current user when absent
- align internal delete and query operations with user-based naming

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test` *(fails: sqlalchemy.exc.OperationalError, invalid DB configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6891861b3b34832fb1c0d41a0ce2ec6b