### PR TITLE
feat: default process_text collection to user

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1256,9 +1256,7 @@ def process_text(
     form_data: ProcessTextForm,
     user=Depends(get_verified_user),
 ):
-    collection_name = form_data.collection_name
-    if collection_name is None:
-        collection_name = calculate_sha256_string(form_data.content)
+    collection_name = form_data.collection_name if form_data.collection_name else f"user-{user.id}"
 
     docs = [
         Document(


### PR DESCRIPTION
## Summary
- default retrieval.process_text collection name to `user-{user.id}` when none provided

## Testing
- `PYTHONPATH=backend pytest` *(fails: sqlite3.OperationalError: ... Table 'config' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891893702dc832f849653967f9a4b34