### PR TITLE
Default collection name for batch file processing

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1894,7 +1894,9 @@ def process_files_batch(
     """
     results: List[BatchProcessFilesResult] = []
     errors: List[BatchProcessFilesResult] = []
-    collection_name = form_data.collection_name
+    collection_name = (
+        form_data.collection_name if form_data.collection_name else f"user-{user.id}"
+    )
 
     # Prepare all documents first
     all_docs: List[Document] = []


### PR DESCRIPTION
## Summary
- default to user-specific collection name in batch file processing when none provided
- continue to use final collection name when updating file metadata

## Testing
- `pytest` *(errors: ModuleNotFoundError: open_webui, test.util, moto)*

------
https://chatgpt.com/codex/tasks/task_e_689193be1688832f981f87d3ea3dece1