### PR TITLE
feat: allow search expr for vector clients

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -64,7 +64,11 @@ class ChromaClient:
         return self.client.delete_collection(name=collection_name)
 
     def search(
-        self, collection_name: str, vectors: list[list[float | int]], limit: int
+        self,
+        collection_name: str,
+        vectors: list[list[float | int]],
+        limit: int,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         # Search for the nearest neighbor items based on the vectors and return 'limit' number of results.
         try:

--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -146,7 +146,11 @@ class ElasticsearchClient:
 
     # Status: works
     def search(
-        self, collection_name: str, vectors: list[list[float]], limit: int
+        self,
+        collection_name: str,
+        vectors: list[list[float]],
+        limit: int,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         query = {
             "size": limit,

--- a/backend/open_webui/retrieval/vector/dbs/milvus.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus.py
@@ -148,7 +148,11 @@ class MilvusClient:
         )
 
     def search(
-        self, collection_name: str, vectors: list[list[float | int]], limit: int
+        self,
+        collection_name: str,
+        vectors: list[list[float | int]],
+        limit: int,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         # Search for the nearest neighbor items based on the vectors and return 'limit' number of results.
         collection_name = collection_name.replace("-", "_")
@@ -157,6 +161,7 @@ class MilvusClient:
             data=vectors,
             limit=limit,
             output_fields=["data", "metadata"],
+            expr=expr,
         )
 
         return self._result_to_search_result(result)

--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -107,7 +107,11 @@ class OpenSearchClient:
         self.client.indices.delete(index=self._get_index_name(collection_name))
 
     def search(
-        self, collection_name: str, vectors: list[list[float | int]], limit: int
+        self,
+        collection_name: str,
+        vectors: list[list[float | int]],
+        limit: int,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         try:
             if not self.has_collection(collection_name):

--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -203,6 +203,7 @@ class PgvectorClient:
         collection_name: str,
         vectors: List[List[float]],
         limit: Optional[int] = None,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         try:
             if not vectors:

--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -83,7 +83,11 @@ class QdrantClient:
         )
 
     def search(
-        self, collection_name: str, vectors: list[list[float | int]], limit: int
+        self,
+        collection_name: str,
+        vectors: list[list[float | int]],
+        limit: int,
+        expr: Optional[str] = None,
     ) -> Optional[SearchResult]:
         # Search for the nearest neighbor items based on the vectors and return 'limit' number of results.
         if limit is None:


### PR DESCRIPTION
## Summary
- extend `MilvusClient.search` with optional `expr` filtering
- add `expr` argument to other vector DB client search interfaces for API consistency

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_6891d2129c44832f9cd76d68bd78f137