### PR TITLE
Implement periodic cleanup for stale file records

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -64,6 +64,7 @@ from open_webui.socket.main import (
     app as socket_app,
     periodic_usage_pool_cleanup,
 )
+from open_webui.tasks import periodic_file_cleanup
 from open_webui.routers import (
     audio,
     images,
@@ -489,6 +490,7 @@ async def lifespan(app: FastAPI):
         get_license_data(app, LICENSE_KEY)
 
     asyncio.create_task(periodic_usage_pool_cleanup())
+    asyncio.create_task(periodic_file_cleanup())
     verify_google_pse(app)
     yield
 

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -1,10 +1,20 @@
 # tasks.py
 import asyncio
+import logging
+import time
 from typing import Dict
 from uuid import uuid4
 
+from open_webui.models.files import Files
+from open_webui.models.knowledge import Knowledges
+from open_webui.retrieval.vector.connector import VECTOR_DB_CLIENT
+from open_webui.env import SRC_LOG_LEVELS
+
 # A dictionary to keep track of active tasks
 tasks: Dict[str, asyncio.Task] = {}
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["MAIN"])
 
 
 def cleanup_task(task_id: str):
@@ -59,3 +69,37 @@ async def stop_task(task_id: str):
         return {"status": True, "message": f"Task {task_id} successfully stopped."}
 
     return {"status": False, "message": f"Failed to stop task {task_id}."}
+
+
+async def periodic_file_cleanup(interval_seconds: int = 3600):
+    """Periodically remove files older than 24 hours not linked to any knowledge base."""
+    while True:
+        try:
+            cutoff = int(time.time()) - 24 * 60 * 60
+            knowledge_file_ids = {
+                fid
+                for knowledge in Knowledges.get_knowledge_bases()
+                for fid in (knowledge.data or {}).get("file_ids", [])
+            }
+            for file in Files.get_files():
+                if (
+                    file.created_at
+                    and file.created_at < cutoff
+                    and file.id not in knowledge_file_ids
+                ):
+                    try:
+                        VECTOR_DB_CLIENT.delete(
+                            collection_name=f"user-{file.user_id}",
+                            filter={"file_id": file.id},
+                        )
+                    except Exception as e:
+                        log.debug("Failed vector delete for %s: %s", file.id, e)
+                    if Files.delete_file_by_id(file.id):
+                        log.info(
+                            "Deleted expired file %s for user %s",
+                            file.id,
+                            file.user_id,
+                        )
+        except Exception:
+            log.exception("Error during periodic file cleanup")
+        await asyncio.sleep(interval_seconds)


### PR DESCRIPTION
## Summary
- add `periodic_file_cleanup` task to remove files older than 24h that aren't linked to a knowledge base
- schedule cleanup on app startup

## Testing
- `pytest backend/open_webui/test -q` *(fails: ModuleNotFoundError: No module named 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_68925e7070fc832f9afacfc7b01c485d