### PR TITLE
Delete vector collection when knowledge removed

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -9,6 +9,7 @@ from open_webui.env import SRC_LOG_LEVELS
 
 from open_webui.models.files import FileMetadataResponse
 from open_webui.models.users import Users, UserResponse
+from open_webui.retrieval.vector.connector import VECTOR_DB_CLIENT
 
 
 from pydantic import BaseModel, ConfigDict
@@ -203,6 +204,11 @@ class KnowledgeTable:
             with get_db() as db:
                 db.query(Knowledge).filter_by(id=id).delete()
                 db.commit()
+                try:
+                    VECTOR_DB_CLIENT.delete_collection(collection_name=id)
+                except Exception as e:
+                    log.debug(e)
+                    pass
                 return True
         except Exception:
             return False


### PR DESCRIPTION
## Summary
- Remove vector DB collection when a knowledge base is deleted
- Ignore errors if the collection is missing to avoid failures

## Testing
- `pytest backend/open_webui/test` *(fails: ModuleNotFoundError: No module named 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_6892711838d8832f8081ca21748c6876