### PR TITLE
Refactor retrieval queries to use single collection with filters

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1709,6 +1709,8 @@ class QueryDocForm(BaseModel):
     k_reranker: Optional[int] = None
     r: Optional[float] = None
     hybrid: Optional[bool] = None
+    filter: Optional[dict] = None
+    filter_expr: Optional[str] = None
 
 
 @router.post("/query/doc")
@@ -1734,6 +1736,8 @@ def query_doc_handler(
                     if form_data.r
                     else request.app.state.config.RELEVANCE_THRESHOLD
                 ),
+                query_filter=form_data.filter,
+                filter_expr=form_data.filter_expr,
                 user=user,
             )
         else:
@@ -1743,6 +1747,8 @@ def query_doc_handler(
                     form_data.query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user
                 ),
                 k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+                query_filter=form_data.filter,
+                filter_expr=form_data.filter_expr,
                 user=user,
             )
     except Exception as e:
@@ -1753,9 +1759,10 @@ def query_doc_handler(
         )
 
 
-class QueryCollectionsForm(BaseModel):
-    collection_names: list[str]
+class QueryCollectionForm(BaseModel):
+    collection_name: str
     query: str
+    filters: Optional[list[dict]] = None
     k: Optional[int] = None
     k_reranker: Optional[int] = None
     r: Optional[float] = None
@@ -1765,13 +1772,13 @@ class QueryCollectionsForm(BaseModel):
 @router.post("/query/collection")
 def query_collection_handler(
     request: Request,
-    form_data: QueryCollectionsForm,
+    form_data: QueryCollectionForm,
     user=Depends(get_verified_user),
 ):
     try:
         if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH:
             return query_collection_with_hybrid_search(
-                collection_names=form_data.collection_names,
+                collection_name=form_data.collection_name,
                 queries=[form_data.query],
                 embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
                     query, prefix=prefix, user=user
@@ -1785,15 +1792,17 @@ def query_collection_handler(
                     if form_data.r
                     else request.app.state.config.RELEVANCE_THRESHOLD
                 ),
+                query_filters=form_data.filters,
             )
         else:
             return query_collection(
-                collection_names=form_data.collection_names,
+                collection_name=form_data.collection_name,
                 queries=[form_data.query],
                 embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
                     query, prefix=prefix, user=user
                 ),
                 k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+                query_filters=form_data.filters,
             )
 
     except Exception as e:

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -465,10 +465,12 @@ export const processWebSearch = async (
 };
 
 export const queryDoc = async (
-	token: string,
-	collection_name: string,
-	query: string,
-	k: number | null = null
+        token: string,
+        collection_name: string,
+        query: string,
+        k: number | null = null,
+        filter: Record<string, unknown> | null = null,
+        filter_expr: string | null = null
 ) => {
 	let error = null;
 
@@ -479,12 +481,14 @@ export const queryDoc = async (
 			'Content-Type': 'application/json',
 			authorization: `Bearer ${token}`
 		},
-		body: JSON.stringify({
-			collection_name: collection_name,
-			query: query,
-			k: k
-		})
-	})
+                body: JSON.stringify({
+                        collection_name: collection_name,
+                        query: query,
+                        k: k,
+                        filter: filter,
+                        filter_expr: filter_expr
+                })
+        })
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();
@@ -502,10 +506,11 @@ export const queryDoc = async (
 };
 
 export const queryCollection = async (
-	token: string,
-	collection_names: string,
-	query: string,
-	k: number | null = null
+        token: string,
+        collection_name: string,
+        query: string,
+        filters: Array<Record<string, unknown>> | null = null,
+        k: number | null = null
 ) => {
 	let error = null;
 
@@ -516,12 +521,13 @@ export const queryCollection = async (
 			'Content-Type': 'application/json',
 			authorization: `Bearer ${token}`
 		},
-		body: JSON.stringify({
-			collection_names: collection_names,
-			query: query,
-			k: k
-		})
-	})
+                body: JSON.stringify({
+                        collection_name: collection_name,
+                        query: query,
+                        filters: filters,
+                        k: k
+                })
+        })
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();


### PR DESCRIPTION
## Summary
- support query filters on retrieval endpoints so clients can work with one collection per user
- update utility functions to search within a single collection using optional filter lists
- adjust frontend API calls to send filters instead of multiple collection names

## Testing
- `pytest` *(fails: No module named 'moto')*
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:backend` *(fails: pylint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893285349f8832fa36144834682602b