### PR TITLE
refactor: document retrieval handlers and refine Milvus logging

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -114,6 +114,7 @@ class VectorSearchRetriever(BaseRetriever):
         *,
         run_manager: CallbackManagerForRetrieverRun,
     ) -> list[Document]:
+        """Retrieve top documents relevant to the query."""
         try:
             result = VECTOR_DB_CLIENT.search(
                 collection_name=self.collection_name,


### PR DESCRIPTION
## Summary
- lower Milvus pagination logging to debug level and document client methods
- add type hints and docstrings for vector search helpers
- document retrieval router handlers and specify return types

## Testing
- `pytest` *(fails: No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_6893dc9db870832f98bd4c89d08441a3