### PR TITLE
Optimize batch file processing duplicate checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed Ameritas Custom Changes - 2025-08-02
 - 🔐**Provider-aware Silent SSO Login**: Silent login now uses the configured OAuth provider instead of a Microsoft-only endpoint.
+- 🧪**Batched duplicate checks for document uploads**: `process_files_batch` now validates empty content and performs a single batched lookup to skip duplicate files more efficiently.
 
 ## [1.2.0] - 2025-04-06
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2063,72 +2063,24 @@ def process_files_batch(
     processed_count = 0
     skipped_count = 0
 
+    file_entries: List[tuple[FileModel, str, str]] = []  # (file, text_content, hash)
+
     for file in form_data.files:
         try:
-            text_content = file.data.get("content", "")
-            hash = calculate_sha256_string(text_content)
-            Files.update_file_hash_by_id(file.id, hash)
-            Files.update_file_data_by_id(file.id, {"content": text_content})
-
-            # Check for duplicate content
-            is_duplicate = False
-            try:
-                existing = VECTOR_DB_CLIENT.query(
-                    collection_name=collection_name, filter={"hash": hash}
+            text_content = file.data.get("content") if file.data else None
+            if not text_content:
+                log.warning(
+                    f"process_files_batch: Empty content for file {file.id}; skipping"
                 )
-                if existing is not None and existing.ids[0]:
-                    is_duplicate = True
-            except Exception as e:
-                log.error(
-                    f"process_files_batch: Error checking duplicate for {file.id}: {str(e)}"
-                )
-
-            if is_duplicate:
-                skipped_count += 1
-                log.info(f"process_files_batch: Skipping duplicate file {file.id}")
                 results.append(
-                    BatchProcessFilesResult(file_id=file.id, status="skipped_duplicate")
+                    BatchProcessFilesResult(file_id=file.id, status="skipped_empty")
                 )
                 continue
 
-            doc_type = (file.meta.get("doc_type") if file.meta else None) or (
-                file.meta.get("content_type") if file.meta else None
-            )
-            if not doc_type:
-                doc_type = mimetypes.guess_type(file.filename)[0]
-
-            docs: List[Document] = [
-                Document(
-                    page_content=text_content.replace("<br/>", "\n"),
-                    metadata={
-                        **file.meta,
-                        "name": file.filename,
-                        "created_by": file.user_id,
-                        "file_id": file.id,
-                        "source": file.filename,
-                        **(
-                            {"session_id": form_data.session_id}
-                            if form_data.session_id
-                            else {}
-                        ),
-                    },
-                )
-            ]
-
-            metadata = {
-                "file_id": file.id,
-                "name": file.filename,
-                "hash": hash,
-                "doc_type": doc_type,
-                **(
-                    {"session_id": form_data.session_id} if form_data.session_id else {}
-                ),
-            }
-
-            all_docs.extend(docs)
-            all_metadata.extend([metadata.copy() for _ in docs])
-            processed_count += len(docs)
-            results.append(BatchProcessFilesResult(file_id=file.id, status="prepared"))
+            hash = calculate_sha256_string(text_content)
+            Files.update_file_hash_by_id(file.id, hash)
+            Files.update_file_data_by_id(file.id, {"content": text_content})
+            file_entries.append((file, text_content, hash))
 
         except Exception as e:
             log.error(f"process_files_batch: Error processing file {file.id}: {str(e)}")
@@ -2137,6 +2089,72 @@ def process_files_batch(
                     file_id=file.id, status="failed", error=getErrorMsg(e)
                 )
             )
+
+    existing_hashes: set[str] = set()
+    hashes = [entry[2] for entry in file_entries]
+    if hashes:
+        try:
+            existing = VECTOR_DB_CLIENT.query(
+                collection_name=collection_name, filter={"hash": hashes}
+            )
+            if existing is not None and existing.metadatas:
+                existing_hashes = {
+                    meta.get("hash")
+                    for meta in existing.metadatas[0]
+                    if meta.get("hash")
+                }
+        except Exception as e:
+            log.error(
+                f"process_files_batch: Error checking duplicates in batch: {str(e)}"
+            )
+
+    for file, text_content, hash in file_entries:
+        if hash in existing_hashes:
+            skipped_count += 1
+            log.info(f"process_files_batch: Skipping duplicate file {file.id}")
+            results.append(
+                BatchProcessFilesResult(file_id=file.id, status="skipped_duplicate")
+            )
+            continue
+
+        doc_type = (file.meta.get("doc_type") if file.meta else None) or (
+            file.meta.get("content_type") if file.meta else None
+        )
+        if not doc_type:
+            doc_type = mimetypes.guess_type(file.filename)[0]
+
+        docs: List[Document] = [
+            Document(
+                page_content=text_content.replace("<br/>", "\n"),
+                metadata={
+                    **file.meta,
+                    "name": file.filename,
+                    "created_by": file.user_id,
+                    "file_id": file.id,
+                    "source": file.filename,
+                    **(
+                        {"session_id": form_data.session_id}
+                        if form_data.session_id
+                        else {}
+                    ),
+                },
+            )
+        ]
+
+        metadata = {
+            "file_id": file.id,
+            "name": file.filename,
+            "hash": hash,
+            "doc_type": doc_type,
+            **(
+                {"session_id": form_data.session_id} if form_data.session_id else {}
+            ),
+        }
+
+        all_docs.extend(docs)
+        all_metadata.extend([metadata.copy() for _ in docs])
+        processed_count += len(docs)
+        results.append(BatchProcessFilesResult(file_id=file.id, status="prepared"))
 
     if all_docs:
         try:

--- a/backend/open_webui/test/apps/webui/routers/test_retrieval.py
+++ b/backend/open_webui/test/apps/webui/routers/test_retrieval.py
@@ -1,0 +1,93 @@
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Ensure env module loads with dictionary configuration before importing open_webui
+tmp = tempfile.NamedTemporaryFile(delete=False)
+tmp.write(json.dumps({}).encode())
+tmp.flush()
+os.environ["ALLOWED_MODULES_FILE"] = tmp.name
+
+from test.util.abstract_integration_test import AbstractPostgresTest
+
+
+
+class DummyVectorClient:
+    def __init__(self):
+        self.calls = []
+
+    def query(self, collection_name, filter):
+        self.calls.append((collection_name, filter))
+        hashes = filter.get("hash", [])
+        if isinstance(hashes, list) and hashes:
+            # Simulate first hash already existing
+            return SimpleNamespace(
+                ids=[["dup"]],
+                documents=[["dup"]],
+                metadatas=[[{"hash": hashes[0]}]],
+            )
+        return SimpleNamespace(ids=[[]], documents=[[]], metadatas=[[]])
+
+
+class TestProcessFilesBatch(AbstractPostgresTest):
+    BASE_PATH = "/api/v1/retrieval"
+
+    def setup_method(self):
+        super().setup_method()
+        from open_webui.models.users import Users
+        from open_webui.models.files import Files
+
+        self.users = Users
+        self.files = Files
+
+        self.user = self.users.insert_new_user(
+            id="u1", name="user", email="user@example.com"
+        )
+
+    def _create_file(self, id, content):
+        from open_webui.models.files import FileForm
+
+        form = FileForm(
+            id=id,
+            filename=f"{id}.txt",
+            path=f"/tmp/{id}.txt",
+            data={"content": content},
+            meta={},
+        )
+        return self.files.insert_new_file(self.user.id, form)
+
+    def test_batch_duplicate_lookup_and_empty_skip(self, monkeypatch):
+        from open_webui.routers import retrieval
+        from open_webui.routers.retrieval import (
+            BatchProcessFilesForm,
+            process_files_batch,
+        )
+
+        file1 = self._create_file("f1", "hello")
+        file2 = self._create_file("f2", "hello")
+        file3 = self._create_file("f3", "")
+
+        dummy_client = DummyVectorClient()
+        monkeypatch.setattr(retrieval, "VECTOR_DB_CLIENT", dummy_client)
+        monkeypatch.setattr(retrieval, "save_docs_to_vector_db", lambda **kwargs: None)
+
+        request = MagicMock()
+        request.app.state.EMBEDDING_FUNCTION = lambda text, prefix=None: [0.0]
+
+        form = BatchProcessFilesForm(
+            files=[file1, file2, file3], collection_name="test_collection"
+        )
+
+        resp = process_files_batch(request, form, self.user)
+
+        # Expect one query for both hashes
+        assert len(dummy_client.calls) == 1
+        assert isinstance(dummy_client.calls[0][1]["hash"], list)
+        # Validate statuses
+        status_map = {r.file_id: r.status for r in resp.results}
+        assert status_map[file1.id] == "skipped_duplicate"
+        assert status_map[file2.id] == "completed"
+        assert status_map[file3.id] == "skipped_empty"
+


### PR DESCRIPTION
## Summary
- validate uploaded file content before hashing, skipping empty files
- check for duplicate document hashes in a single batch query instead of per file
- document batch duplicate behavior and add regression test

## Testing
- `PYTHONPATH=backend:backend/open_webui python -m pytest backend/open_webui/test/apps/webui/routers/test_retrieval.py::TestProcessFilesBatch::test_batch_duplicate_lookup_and_empty_skip -q` *(fails: ConnectionError to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6893f30f9db4832fa191f6112744ed5a