### PR TITLE
Respect file references when removing knowledge files

### DIFF
--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -145,6 +145,7 @@ POST /retrieval/query/collection
 ## Cleanup Behaviour
 
 - Updating a file removes existing vectors for that file before new content is inserted.
+- Removing a file from a knowledge base only deletes the file itself when no other knowledge bases or user collections reference it.
 - A periodic task deletes files older than 24 hours that are not attached to any knowledge base and removes their associated vectors from the user collection. Knowledge base collections are not affected by this cleanup.
 
 These features help keep user collections accurate and free of stale data while maintaining persistent knowledge bases.


### PR DESCRIPTION
## Summary
- add `file_deleted` flag and reference checks to remove API
- document reference-aware file removal
- cover shared-file scenarios with new tests

## Testing
- `PYTHONPATH=backend:backend/open_webui pytest backend/open_webui/test/apps/webui/routers/test_knowledge.py::TestKnowledge::test_cleanup_and_knowledge_deletion_drops_collection backend/open_webui/test/apps/webui/routers/test_knowledge.py::TestKnowledge::test_remove_file_shared_across_knowledge_retains_file -q`

------
https://chatgpt.com/codex/tasks/task_e_6893ffb365bc832f87ac11fb519b27fa