### PR TITLE
feat(auth): replace fetch-based silent login with hidden window

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -161,10 +161,10 @@ Modification Log:
                 }
                await checkOauthCallback();
 
-               const providerParam = querystringValue('provider');
-               const providers = providerParam
-                       ? [providerParam]
-                       : Object.keys($config?.oauth?.providers ?? {});
+              const providerParam = querystringValue('provider');
+              const providers = providerParam !== null
+                      ? [providerParam]
+                      : Object.keys($config?.oauth?.providers ?? {});
 
                const shouldAttemptSilent =
                        sessionStorage.getItem('attemptSilentLogin') === 'true' ||


### PR DESCRIPTION
## Summary
- replace fetch-based silent login with window.open and sessionStorage guard

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration, svelte-kit missing)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944efed730832fa0269d5a3e64dcf2