### PR TITLE
chore: add debug logs for silent login

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -173,6 +173,19 @@ Modification Log:
                if (shouldAttemptSilent) {
                        for (const provider of providers) {
                                console.log('Attempting silent login for provider:', provider);
+                               try {
+                                       const resp = await fetch(
+                                               `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
+                                               {
+                                                       credentials: 'include'
+                                               }
+                                       );
+                                       console.log('Response status:', resp.status);
+                                       console.log('Response headers:', resp.headers);
+                               } catch (err) {
+                                       console.error('Silent login fetch failed:', err);
+                               }
+
                                const silentAuthWindow = window.open(
                                        `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
                                        'silent-auth',


### PR DESCRIPTION
## Summary
- add console debug logs for silent OAuth login attempts and fetch responses

## Testing
- `npm test` (fails: Missing script)
- `npm install --omit=optional` (fails: install script for onnxruntime-node, ENETUNREACH)
- `npm run dev` (fails: Cannot find package 'pyodide')

------
https://chatgpt.com/codex/tasks/task_e_689457825254832fa81e40f92edbd926