### PR TITLE
Always attempt silent OAuth login

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -57,13 +57,14 @@
 
         let version;
 
-	onMount(async () => {
-		if ($user === undefined) {
-			await goto('/auth');
-		} else if (['user', 'admin'].includes($user.role)) {
-			try {
-				// Check if IndexedDB exists
-				DB = await openDB('Chats', 1);
+       onMount(async () => {
+               if ($user === undefined) {
+                       sessionStorage.setItem('attemptSilentLogin', 'true');
+                       await goto('/auth');
+               } else if (['user', 'admin'].includes($user.role)) {
+                       try {
+                               // Check if IndexedDB exists
+                               DB = await openDB('Chats', 1);
 
 				if (DB) {
 					const chats = await DB.getAllFromIndex('chats', 'timestamp');

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -166,39 +166,20 @@ Modification Log:
                       ? [providerParam]
                       : Object.keys($config?.oauth?.providers ?? {});
 
-               const shouldAttemptSilent =
-                       sessionStorage.getItem('attemptSilentLogin') === 'true' ||
-                       providerParam !== null;
-
-               if (shouldAttemptSilent) {
-                       for (const provider of providers) {
-                               console.log('Attempting silent login for provider:', provider);
-                               try {
-                                       const resp = await fetch(
-                                               `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
-                                               {
-                                                       credentials: 'include'
-                                               }
-                                       );
-                                       console.log('Response status:', resp.status);
-                                       console.log('Response headers:', resp.headers);
-                               } catch (err) {
-                                       console.error('Silent login fetch failed:', err);
+               for (const provider of providers) {
+                       console.log('Attempting silent login for provider:', provider);
+                       const silentAuthWindow = window.open(
+                               `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
+                               'silent-auth',
+                               'width=1,height=1,left=-1000,top=-1000'
+                       );
+                       setTimeout(() => {
+                               if (silentAuthWindow && !silentAuthWindow.closed) {
+                                       silentAuthWindow.close();
                                }
-
-                               const silentAuthWindow = window.open(
-                                       `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
-                                       'silent-auth',
-                                       'width=1,height=1,left=-1000,top=-1000'
-                               );
-                               setTimeout(() => {
-                                       if (silentAuthWindow && !silentAuthWindow.closed) {
-                                               silentAuthWindow.close();
-                                       }
-                               }, 3000);
-                       }
-                       sessionStorage.removeItem('attemptSilentLogin');
+                       }, 3000);
                }
+               sessionStorage.removeItem('attemptSilentLogin');
                loaded = true;
                setLogoImage();
 


### PR DESCRIPTION
## Summary
- Always run silent-login for each provider on the auth page without gating on session storage.
- Remember to attempt silent login once per visit by setting a session flag before redirecting to `/auth` from the app layout.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: ENETUNREACH fetching packages)*
- `npm run lint` *(fails: ESLint config and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68945b461ac0832fa55b587f96d7a219