### PR TITLE
feat: stream reasoning updates

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -249,13 +249,13 @@
 			</ul>
 		{/if}
 	{:else if token.type === 'details'}
-		<Collapsible
-			title={token.summary}
-			open={$settings?.expandDetails ?? false}
-			attributes={token?.attributes}
-			className="w-full space-y-1"
-			dir="auto"
-		>
+                <Collapsible
+                        title={token.summary}
+                        open={token?.attributes?.open !== undefined ? true : $settings?.expandDetails ?? false}
+                        attributes={token?.attributes}
+                        className="w-full space-y-1"
+                        dir="auto"
+                >
 			<div class=" mb-1.5" slot="content">
 				<svelte:self
 					id={`${id}-${tokenIdx}-d`}


### PR DESCRIPTION
## Summary
- include `reasoning` in streaming updates and keep chunks intact
- surface reasoning deltas in Chat UI, wrapping them in live collapsible
- auto-open reasoning collapsible when extended thinking is enabled

## Testing
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install vitest --no-save` *(fails: connect ENETUNREACH 140.82.112.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_6894802b7dc0832f979a4e8b46dd6fcf