### PR TITLE
Add reasoning capability flag

### DIFF
--- a/src/lib/components/workspace/Models/Capabilities.svelte
+++ b/src/lib/components/workspace/Models/Capabilities.svelte
@@ -11,14 +11,16 @@
 		usage: $i18n.t(
 			'Sends `stream_options: { include_usage: true }` in the request.\nSupported providers will return token usage information in the response when set.'
 		),
-		citations: $i18n.t('Displays citations in the response')
-	};
+                citations: $i18n.t('Displays citations in the response'),
+                reasoning: $i18n.t('Enables advanced reasoning capabilities')
+        };
 
-	export let capabilities: {
-		vision?: boolean;
-		usage?: boolean;
-		citations?: boolean;
-	} = {};
+        export let capabilities: {
+                vision?: boolean;
+                usage?: boolean;
+                citations?: boolean;
+                reasoning?: boolean;
+        } = {};
 </script>
 
 <div>

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -73,11 +73,12 @@
 	let params = {
 		system: ''
 	};
-	let capabilities = {
-		vision: true,
-		usage: undefined,
-		citations: true
-	};
+        let capabilities = {
+                vision: true,
+                usage: undefined,
+                citations: true,
+                reasoning: false
+        };
 
 	let knowledge = [];
 	let toolIds = [];
@@ -113,8 +114,8 @@
 			toast.error('Model Name is required.');
 		}
 
-		info.access_control = accessControl;
-		info.meta.capabilities = capabilities;
+                info.access_control = accessControl;
+                info.meta.capabilities = { ...capabilities, reasoning: capabilities.reasoning };
 
 		if (enableDescription) {
 			info.meta.description = info.meta.description.trim() === '' ? null : info.meta.description;


### PR DESCRIPTION
## Summary
- add reasoning help text and interface entry for model capabilities
- track reasoning flag in model editor and propagate to meta capabilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689490415dd0832fae0c96de0a679836