### PR TITLE
Add extended thinking parameter locking

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -136,32 +136,59 @@
 	let prompt = '';
 	let chatFiles = [];
 	let files = [];
-	let params = {};
-	let previousReasoningEffort = undefined;
-	let previousTemperature = undefined;
-	let extendedThinkingWasEnabled = false;
-	$: if (extendedThinkingEnabled) {
-		previousReasoningEffort = params.reasoning_effort;
-		previousTemperature = params.temperature;
-		params = { ...params, reasoning_effort: 'high', temperature: 1 };
-		extendedThinkingWasEnabled = true;
-	} else if (extendedThinkingWasEnabled) {
-		let newParams = { ...params };
-		if (previousReasoningEffort !== undefined) {
-			newParams.reasoning_effort = previousReasoningEffort;
-		} else {
-			delete newParams.reasoning_effort;
-		}
-		if (previousTemperature !== undefined) {
-			newParams.temperature = previousTemperature;
-		} else {
-			delete newParams.temperature;
-		}
-		params = newParams;
-		previousReasoningEffort = undefined;
-		previousTemperature = undefined;
-		extendedThinkingWasEnabled = false;
-	}
+        let params = {};
+        let previousReasoningEffort = undefined;
+        let previousTemperature = undefined;
+        let previousStreamResponse = undefined;
+        let previousThinking = undefined;
+        let previousSelectedModels: string[] = [];
+        let extendedThinkingWasEnabled = false;
+        $: if (extendedThinkingEnabled) {
+                previousReasoningEffort = params.reasoning_effort;
+                previousTemperature = params.temperature;
+                previousStreamResponse = params.stream_response;
+                previousThinking = params.thinking;
+                previousSelectedModels = [...selectedModels];
+                params = {
+                        ...params,
+                        reasoning_effort: 'high',
+                        temperature: 1,
+                        stream_response: true,
+                        thinking: { type: 'enabled', budget_tokens: 5000 }
+                };
+                selectedModels = ['claude'];
+                extendedThinkingWasEnabled = true;
+        } else if (extendedThinkingWasEnabled) {
+                let newParams = { ...params };
+                if (previousReasoningEffort !== undefined) {
+                        newParams.reasoning_effort = previousReasoningEffort;
+                } else {
+                        delete newParams.reasoning_effort;
+                }
+                if (previousTemperature !== undefined) {
+                        newParams.temperature = previousTemperature;
+                } else {
+                        delete newParams.temperature;
+                }
+                if (previousStreamResponse !== undefined) {
+                        newParams.stream_response = previousStreamResponse;
+                } else {
+                        delete newParams.stream_response;
+                }
+                if (previousThinking !== undefined) {
+                        newParams.thinking = previousThinking;
+                } else {
+                        delete newParams.thinking;
+                }
+                params = newParams;
+                selectedModels = previousSelectedModels;
+                previousReasoningEffort = undefined;
+                previousTemperature = undefined;
+                previousStreamResponse = undefined;
+                previousThinking = undefined;
+                previousSelectedModels = [];
+                extendedThinkingWasEnabled = false;
+        }
 
 	$: if (chatIdProp) {
 		(async () => {

--- a/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
@@ -69,39 +69,51 @@ describe('ToolsMenu', () => {
 	});
 });
 
-test('extended thinking sets temperature to 1 and restores previous value', async () => {
-	const { component } = render(ToolsMenu, {
-		props: {
-			selectedToolIds: [],
-			webSearchEnabled: false,
-			codeInterpreterEnabled: false,
-			imageGenerationEnabled: false,
-			extendedThinkingEnabled: false,
-			reasoningCapable: true,
-			onClose: () => {},
-			params: { temperature: 0.7 }
-		},
-		context: new Map([
-			[
-				'i18n',
-				{
-					subscribe: (run: Function) => {
-						run({ t: (s: string) => s });
-						return () => {};
-					}
-				}
-			]
-		])
-	});
+test('extended thinking updates params and restores previous values', async () => {
+        const { component } = render(ToolsMenu, {
+                props: {
+                        selectedToolIds: [],
+                        webSearchEnabled: false,
+                        codeInterpreterEnabled: false,
+                        imageGenerationEnabled: false,
+                        extendedThinkingEnabled: false,
+                        reasoningCapable: true,
+                        onClose: () => {},
+                        params: { temperature: 0.7, stream_response: false },
+                        selectedModels: ['llama']
+                },
+                context: new Map([
+                        [
+                                'i18n',
+                                {
+                                        subscribe: (run: Function) => {
+                                                run({ t: (s: string) => s });
+                                                return () => {};
+                                        }
+                                }
+                        ]
+                ])
+        });
 
-	const getParams = () => component.$$.ctx[component.$$.props['params']];
-	expect(getParams().temperature).toBe(0.7);
+        const getParams = () => component.$$.ctx[component.$$.props['params']];
+        const getSelectedModels = () => component.$$.ctx[component.$$.props['selectedModels']];
 
-	component.$set({ extendedThinkingEnabled: true });
-	await tick();
-	expect(getParams().temperature).toBe(1);
+        expect(getParams().temperature).toBe(0.7);
+        expect(getParams().stream_response).toBe(false);
+        expect(getParams().thinking).toBeUndefined();
+        expect(getSelectedModels()).toEqual(['llama']);
 
-	component.$set({ extendedThinkingEnabled: false });
-	await tick();
-	expect(getParams().temperature).toBe(0.7);
+        component.$set({ extendedThinkingEnabled: true });
+        await tick();
+        expect(getParams().temperature).toBe(1);
+        expect(getParams().stream_response).toBe(true);
+        expect(getParams().thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+        expect(getSelectedModels()).toEqual(['claude']);
+
+        component.$set({ extendedThinkingEnabled: false });
+        await tick();
+        expect(getParams().temperature).toBe(0.7);
+        expect(getParams().stream_response).toBe(false);
+        expect(getParams().thinking).toBeUndefined();
+        expect(getSelectedModels()).toEqual(['llama']);
 });

--- a/src/lib/components/chat/MessageInput/ToolsMenuTestWrapper.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenuTestWrapper.svelte
@@ -4,37 +4,65 @@
 	export let webSearchEnabled = false;
 	export let codeInterpreterEnabled = false;
 	export let imageGenerationEnabled = false;
-	export let extendedThinkingEnabled = false;
-	export let reasoningCapable = true;
-	export let onClose: Function = () => {};
-	export let params = {};
+        export let extendedThinkingEnabled = false;
+        export let reasoningCapable = true;
+        export let onClose: Function = () => {};
+        export let params = {};
+        export let selectedModels: string[] = [];
 
-	let previousReasoningEffort = undefined;
-	let previousTemperature = undefined;
-	let extendedThinkingWasEnabled = false;
+        let previousReasoningEffort = undefined;
+        let previousTemperature = undefined;
+        let previousStreamResponse = undefined;
+        let previousThinking = undefined;
+        let previousSelectedModels: string[] = [];
+        let extendedThinkingWasEnabled = false;
 
-	$: if (extendedThinkingEnabled) {
-		previousReasoningEffort = params.reasoning_effort;
-		previousTemperature = params.temperature;
-		params = { ...params, reasoning_effort: 'high', temperature: 1 };
-		extendedThinkingWasEnabled = true;
-	} else if (extendedThinkingWasEnabled) {
-		let newParams = { ...params };
-		if (previousReasoningEffort !== undefined) {
-			newParams.reasoning_effort = previousReasoningEffort;
-		} else {
-			delete newParams.reasoning_effort;
-		}
-		if (previousTemperature !== undefined) {
-			newParams.temperature = previousTemperature;
-		} else {
-			delete newParams.temperature;
-		}
-		params = newParams;
-		previousReasoningEffort = undefined;
-		previousTemperature = undefined;
-		extendedThinkingWasEnabled = false;
-	}
+        $: if (extendedThinkingEnabled) {
+                previousReasoningEffort = params.reasoning_effort;
+                previousTemperature = params.temperature;
+                previousStreamResponse = params.stream_response;
+                previousThinking = params.thinking;
+                previousSelectedModels = [...selectedModels];
+                params = {
+                        ...params,
+                        reasoning_effort: 'high',
+                        temperature: 1,
+                        stream_response: true,
+                        thinking: { type: 'enabled', budget_tokens: 5000 }
+                };
+                selectedModels = ['claude'];
+                extendedThinkingWasEnabled = true;
+        } else if (extendedThinkingWasEnabled) {
+                let newParams = { ...params };
+                if (previousReasoningEffort !== undefined) {
+                        newParams.reasoning_effort = previousReasoningEffort;
+                } else {
+                        delete newParams.reasoning_effort;
+                }
+                if (previousTemperature !== undefined) {
+                        newParams.temperature = previousTemperature;
+                } else {
+                        delete newParams.temperature;
+                }
+                if (previousStreamResponse !== undefined) {
+                        newParams.stream_response = previousStreamResponse;
+                } else {
+                        delete newParams.stream_response;
+                }
+                if (previousThinking !== undefined) {
+                        newParams.thinking = previousThinking;
+                } else {
+                        delete newParams.thinking;
+                }
+                params = newParams;
+                selectedModels = previousSelectedModels;
+                previousReasoningEffort = undefined;
+                previousTemperature = undefined;
+                previousStreamResponse = undefined;
+                previousThinking = undefined;
+                previousSelectedModels = [];
+                extendedThinkingWasEnabled = false;
+        }
 </script>
 
 <ToolsMenu

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -61,26 +61,32 @@
 				<div class=" self-center text-xs font-medium">
 					{$i18n.t('Stream Chat Response')}
 				</div>
-				<button
-					class="p-1 px-3 text-xs flex rounded-sm transition"
-					on:click={() => {
-						params.stream_response =
-							(params?.stream_response ?? null) === null
-								? true
-								: params.stream_response
-									? false
-									: null;
-					}}
-					type="button"
-				>
-					{#if params.stream_response === true}
-						<span class="ml-2 self-center">{$i18n.t('On')}</span>
-					{:else if params.stream_response === false}
-						<span class="ml-2 self-center">{$i18n.t('Off')}</span>
-					{:else}
-						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
-					{/if}
-				</button>
+                                {#if extendedThinkingEnabled}
+                                        <div class="p-1 px-3 text-xs flex rounded-sm transition">
+                                                <span class="ml-2 self-center">{$i18n.t('On')}</span>
+                                        </div>
+                                {:else}
+                                        <button
+                                                class="p-1 px-3 text-xs flex rounded-sm transition"
+                                                on:click={() => {
+                                                        params.stream_response =
+                                                                (params?.stream_response ?? null) === null
+                                                                        ? true
+                                                                        : params.stream_response
+                                                                                ? false
+                                                                                : null;
+                                                }}
+                                                type="button"
+                                        >
+                                                {#if params.stream_response === true}
+                                                        <span class="ml-2 self-center">{$i18n.t('On')}</span>
+                                                {:else if params.stream_response === false}
+                                                        <span class="ml-2 self-center">{$i18n.t('Off')}</span>
+                                                {:else}
+                                                        <span class="ml-2 self-center">{$i18n.t('Default')}</span>
+                                                {/if}
+                                        </button>
+                                {/if}
 			</div>
 		</Tooltip>
 	</div>
@@ -274,36 +280,40 @@
 				<div class=" self-center text-xs font-medium">
 					{$i18n.t('Reasoning Effort')}
 				</div>
-				<button
-					class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
-					type="button"
-					on:click={() => {
-						params.reasoning_effort = (params?.reasoning_effort ?? null) === null ? 'medium' : null;
-					}}
-				>
-					{#if (params?.reasoning_effort ?? null) === null}
-						<span class="ml-2 self-center"> {$i18n.t('Default')} </span>
-					{:else}
-						<span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
-					{/if}
-				</button>
-			</div>
-		</Tooltip>
+                                {#if extendedThinkingEnabled}
+                                        <span class="ml-2 self-center">{$i18n.t('High')}</span>
+                                {:else}
+                                        <button
+                                                class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
+                                                type="button"
+                                                on:click={() => {
+                                                        params.reasoning_effort = (params?.reasoning_effort ?? null) === null ? 'medium' : null;
+                                                }}
+                                        >
+                                                {#if (params?.reasoning_effort ?? null) === null}
+                                                        <span class="ml-2 self-center"> {$i18n.t('Default')} </span>
+                                                {:else}
+                                                        <span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
+                                                {/if}
+                                        </button>
+                                {/if}
+                        </div>
+                </Tooltip>
 
-		{#if (params?.reasoning_effort ?? null) !== null}
-			<div class="flex mt-0.5 space-x-2">
-				<div class=" flex-1">
-					<input
-						class="w-full rounded-lg py-2 px-1 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden"
-						type="text"
-						placeholder={$i18n.t('Enter reasoning effort')}
-						bind:value={params.reasoning_effort}
-						autocomplete="off"
-					/>
-				</div>
-			</div>
-		{/if}
-	</div>
+                {#if !extendedThinkingEnabled && (params?.reasoning_effort ?? null) !== null}
+                        <div class="flex mt-0.5 space-x-2">
+                                <div class=" flex-1">
+                                        <input
+                                                class="w-full rounded-lg py-2 px-1 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+                                                type="text"
+                                                placeholder={$i18n.t('Enter reasoning effort')}
+                                                bind:value={params.reasoning_effort}
+                                                autocomplete="off"
+                                        />
+                                </div>
+                        </div>
+                {/if}
+        </div>
 
 	<div class=" py-0.5 w-full justify-between">
 		<Tooltip


### PR DESCRIPTION
## Summary
- Preserve chat parameter state and model selection when toggling Extended Thinking, forcing streaming, reasoning, and Claude while active
- Lock Stream Response and Reasoning Effort controls in Advanced settings when Extended Thinking is enabled
- Mirror Extended Thinking logic in test wrapper and add tests for parameter updates and restoration

## Testing
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954ff11988832f9e6e696fdb3dbc74