### PR TITLE
feat: add reasoning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ For more information, be sure to check out OpenwebUI documentation [Open WebUI D
 - 🔐 **Role-Based Access Control (RBAC)**: Ensure secure access with restricted permissions; only authorized individuals can access your Ollama, and exclusive model creation/pulling rights are reserved for administrators.
 - 🌐🌍 **Multilingual Support**: Experience Open WebUI in your preferred language with our internationalization (i18n) support. Join us in expanding our supported languages! We're actively seeking contributors!
 
+## Reasoning Models
+
+Supported models flagged with reasoning capability automatically receive a system prompt of
+`Think step by step: <think></think>`. For OpenAI models, a dummy `reason` tool is also
+exposed so the model can stream its thought process via function calls. Operators can
+optionally control how much the model thinks by setting the `reasoning_effort` parameter
+in model or request settings.
+
   
   
 ## Deployment Configuration

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -880,6 +880,17 @@ OPENAI_API_CONFIGS = PersistentConfig(
     {},
 )
 
+OPENAI_REASONING_MODELS = os.environ.get("OPENAI_REASONING_MODELS", "")
+OPENAI_REASONING_MODELS = (
+    [m.strip() for m in OPENAI_REASONING_MODELS.split(",") if m.strip()]
+    or ["o1-mini", "o1-preview"]
+)
+OPENAI_REASONING_MODELS = PersistentConfig(
+    "OPENAI_REASONING_MODELS",
+    "openai.reasoning_models",
+    OPENAI_REASONING_MODELS,
+)
+
 # Get the actual OpenAI API key based on the base URL
 OPENAI_API_KEY = ""
 try:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -118,6 +118,7 @@ from open_webui.config import (
     OPENAI_API_BASE_URLS,
     OPENAI_API_KEYS,
     OPENAI_API_CONFIGS,
+    OPENAI_REASONING_MODELS,
     # Direct Connections
     ENABLE_DIRECT_CONNECTIONS,
     # Code Execution
@@ -546,6 +547,7 @@ app.state.config.ENABLE_OPENAI_API = ENABLE_OPENAI_API
 app.state.config.OPENAI_API_BASE_URLS = OPENAI_API_BASE_URLS
 app.state.config.OPENAI_API_KEYS = OPENAI_API_KEYS
 app.state.config.OPENAI_API_CONFIGS = OPENAI_API_CONFIGS
+app.state.config.OPENAI_REASONING_MODELS = OPENAI_REASONING_MODELS
 
 app.state.OPENAI_MODELS = {}
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -534,6 +534,7 @@ async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
     def merge_models_lists(model_lists):
         log.debug(f"merge_models_lists {model_lists}")
         merged_list = []
+        reasoning_models = set(request.app.state.config.OPENAI_REASONING_MODELS)
 
         for idx, models in enumerate(model_lists):
             if models is not None and "error" not in models:
@@ -546,6 +547,17 @@ async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
                             "owned_by": "openai",
                             "openai": model,
                             "urlIdx": idx,
+                            **(
+                                {
+                                    "info": {
+                                        "meta": {
+                                            "capabilities": {"reasoning": True}
+                                        }
+                                    }
+                                }
+                                if model.get("id") in reasoning_models
+                                else {}
+                            ),
                         }
                         for model in models
                         if (model.get("id") or model.get("name"))

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -697,6 +697,37 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     else:
         models = request.app.state.MODELS
 
+    reasoning_capable = (
+        model.get("info", {})
+        .get("meta", {})
+        .get("capabilities", {})
+        .get("reasoning", False)
+    )
+    if reasoning_capable:
+        form_data["messages"] = add_or_update_system_message(
+            "Think step by step: <think></think>",
+            form_data.get("messages", []),
+        )
+        if model.get("owned_by") == "openai":
+            reason_tool = {
+                "type": "function",
+                "function": {
+                    "name": "reason",
+                    "description": "Expose reasoning steps",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"reason": {"type": "string"}},
+                        "required": ["reason"],
+                    },
+                },
+            }
+            form_data.setdefault("tools", [])
+            if all(
+                t.get("function", {}).get("name") != "reason"
+                for t in form_data["tools"]
+            ):
+                form_data["tools"].append(reason_tool)
+
     task_model_id = get_task_model_id(
         form_data["model"],
         request.app.state.config.TASK_MODEL,


### PR DESCRIPTION
## Summary
- inject reasoning system prompt and expose `reason` tool for OpenAI reasoning models
- add configuration for reasoning-capable models and mark them during model discovery
- document reasoning prompt and `reasoning_effort` usage for operators

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_68955e1cc06c832fad58640ca065d909