### PR TITLE
feat: gate reasoning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ can stream its thought process via function calls. Operators can optionally cont
 much the model thinks by setting the `reasoning_effort` parameter in model or request
 settings. Configure the `OPENAI_REASONING_MODELS` environment variable to list IDs of
 reasoning-capable models.
+Administrators may override automatic detection entirely by setting the
+`REASONING_OVERRIDE` environment variable to `true` or `false`.
 
 ## Deployment Configuration
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -896,6 +896,17 @@ OPENAI_REASONING_MODELS = PersistentConfig(
     OPENAI_REASONING_MODELS,
 )
 
+REASONING_OVERRIDE = os.environ.get("REASONING_OVERRIDE", "").lower()
+if REASONING_OVERRIDE not in ["true", "false"]:
+    REASONING_OVERRIDE = None
+else:
+    REASONING_OVERRIDE = REASONING_OVERRIDE == "true"
+REASONING_OVERRIDE = PersistentConfig(
+    "REASONING_OVERRIDE",
+    "openai.reasoning_override",
+    REASONING_OVERRIDE,
+)
+
 # Get the actual OpenAI API key based on the base URL
 OPENAI_API_KEY = ""
 try:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -119,6 +119,7 @@ from open_webui.config import (
     OPENAI_API_KEYS,
     OPENAI_API_CONFIGS,
     OPENAI_REASONING_MODELS,
+    REASONING_OVERRIDE,
     # Direct Connections
     ENABLE_DIRECT_CONNECTIONS,
     # Code Execution
@@ -548,6 +549,7 @@ app.state.config.OPENAI_API_BASE_URLS = OPENAI_API_BASE_URLS
 app.state.config.OPENAI_API_KEYS = OPENAI_API_KEYS
 app.state.config.OPENAI_API_CONFIGS = OPENAI_API_CONFIGS
 app.state.config.OPENAI_REASONING_MODELS = OPENAI_REASONING_MODELS
+app.state.config.REASONING_OVERRIDE = REASONING_OVERRIDE
 
 app.state.OPENAI_MODELS = {}
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -697,8 +697,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     else:
         models = request.app.state.MODELS
 
+    override = request.app.state.config.REASONING_OVERRIDE
     reasoning_capable = (
-        model.get("info", {})
+        override
+        if override is not None
+        else metadata.get("model", {})
+        .get("info", {})
         .get("meta", {})
         .get("capabilities", {})
         .get("reasoning", False)
@@ -1554,8 +1558,16 @@ async def process_chat_response(
                 }
             ]
 
-            # We might want to disable this by default
-            DETECT_REASONING = True
+            override = request.app.state.config.REASONING_OVERRIDE
+            DETECT_REASONING = (
+                override
+                if override is not None
+                else metadata.get("model", {})
+                .get("info", {})
+                .get("meta", {})
+                .get("capabilities", {})
+                .get("reasoning", False)
+            )
             DETECT_SOLUTION = True
             DETECT_CODE_INTERPRETER = metadata.get("features", {}).get(
                 "code_interpreter", False

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -217,6 +217,15 @@ async def get_all_models(request, user: UserModel = None):
             model["actions"].extend(
                 get_action_items_from_module(action_function, function_module)
             )
+    reasoning_models = set(request.app.state.config.OPENAI_REASONING_MODELS)
+    for model in models:
+        if model.get("id") in reasoning_models:
+            (
+                model.setdefault("info", {})
+                .setdefault("meta", {})
+                .setdefault("capabilities", {})
+            )["reasoning"] = True
+
     log.debug(f"get_all_models() returned {len(models)} models")
 
     request.app.state.MODELS = {model["id"]: model for model in models}


### PR DESCRIPTION
## Summary
- gate reasoning detection behind metadata or admin override
- mark configured models as reasoning capable on registration
- document reasoning override flag

## Testing
- `pytest backend/open_webui/test/apps/webui/routers/test_models.py` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_6895c0f1bf84832f8334735506caaaf4