### PR TITLE
Show reasoning duration in chat messages

### DIFF
--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -89,7 +89,7 @@ async function* openAIStreamToIterator(
                                 parsedData.choices?.[0]?.delta?.reasoning ??
                                 parsedData.choices?.[0]?.message?.reasoning ??
                                 parsedData.reasoning;
-                        if (reasoning) {
+                        if (reasoning !== undefined) {
                                 yield { done: false, value: '', reasoning };
                         }
 
@@ -133,7 +133,7 @@ async function* streamLargeDeltasAsRandomChunks(
                         yield textStreamUpdate;
                         continue;
                 }
-                if (textStreamUpdate.reasoning) {
+                if (textStreamUpdate.reasoning !== undefined) {
                         yield textStreamUpdate;
                         continue;
                 }

--- a/src/lib/components/chat/ReasoningTransition.test.ts
+++ b/src/lib/components/chat/ReasoningTransition.test.ts
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import Collapsible from '$lib/components/common/Collapsible.svelte';
+
+describe('Reasoning UI', () => {
+        test('transitions from Thinking... to Thought for X seconds', async () => {
+                const { getByText, component } = render(Collapsible, {
+                        props: {
+                                attributes: { type: 'reasoning', done: 'false' }
+                        },
+                        context: new Map([
+                                [
+                                        'i18n',
+                                        {
+                                                subscribe: (run: Function) => {
+                                                        run({
+                                                                t: (s: string, vars?: Record<string, any>) =>
+                                                                        vars
+                                                                                ? s.replace(/\{\{(.*?)\}\}/g, (_, k) =>
+                                                                                          vars[k.trim()] ?? ''
+                                                                                  )
+                                                                                : s,
+                                                                languages: ['en-US']
+                                                        });
+                                                        return () => {};
+                                                }
+                                        }
+                                ]
+                        ])
+                });
+
+                getByText('Thinking...');
+
+                component.$set({ attributes: { type: 'reasoning', done: 'true', duration: 3 } });
+                await tick();
+
+                getByText('Thought for 3 seconds');
+        });
+});


### PR DESCRIPTION
## Summary
- trigger reasoning state when SSE includes reasoning field
- show "Thinking..." instantly and mark completion with duration
- add smoke test for transition to "Thought for X seconds"

## Testing
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6896583cd848832fb9852e36a6497b38