### PR TITLE
Add merge revision to unify Alembic heads

### DIFF
--- a/backend/open_webui/migrations/versions/1debf1274c22_merge_heads.py
+++ b/backend/open_webui/migrations/versions/1debf1274c22_merge_heads.py
@@ -1,0 +1,27 @@
+"""Merge heads
+
+Revision ID: 1debf1274c22
+Revises: 3781e22d8b01, b8a2c3f2d1a4
+Create Date: 2025-08-08 22:23:48.037559
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import open_webui.internal.db
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1debf1274c22'
+down_revision: Union[str, None] = ('3781e22d8b01', 'b8a2c3f2d1a4')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Merge diverging Alembic heads into single revision

## Testing
- `PYTHONPATH=/workspace/scout/backend ALLOWED_MODULES_FILE=/workspace/scout/backend/ALLOWED_MODULES.json alembic upgrade head` *(fails: NotImplementedError: No support for ALTER of constraints in SQLite dialect)*
- `PYTHONPATH=/workspace/scout/backend ALLOWED_MODULES_FILE=/workspace/scout/backend/ALLOWED_MODULES.json pytest -q` *(fails: ModuleNotFoundError: No module named 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_689676cff2e8832f9fb16172a5577714