### PR TITLE
Enable cookie-based session fetch after silent login

### DIFF
--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -82,22 +82,22 @@ export const updateAdminConfig = async (token: string, body: object) => {
 	return res;
 };
 
-export const getSessionUser = async (token: string) => {
-	let error = null;
+export const getSessionUser = async (token?: string) => {
+        let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/`, {
-		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		},
-		credentials: 'include'
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
+        const res = await fetch(`${WEBUI_API_BASE_URL}/auths/`, {
+                method: 'GET',
+                headers: {
+                        'Content-Type': 'application/json',
+                        ...(token && { Authorization: `Bearer ${token}` })
+                },
+                credentials: 'include'
+        })
+                .then(async (res) => {
+                        if (!res.ok) throw await res.json();
+                        return res.json();
+                })
+                .catch((err) => {
 			console.log(err);
 			error = err.detail;
 			return null;

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -173,12 +173,21 @@ Modification Log:
                                'silent-auth',
                                'width=1,height=1,left=-1000,top=-1000'
                        );
-                       setTimeout(() => {
+                       setTimeout(async () => {
                                if (silentAuthWindow && !silentAuthWindow.closed) {
                                        silentAuthWindow.close();
-                                        }
+                               }
+
+                               const sessionUser = await getSessionUser().catch((error) => {
+                                       console.log(error);
+                                       return null;
+                               });
+
+                               if (sessionUser) {
+                                       await setSessionUser(sessionUser);
+                               }
                        }, 3000);
-                        }
+                       }
                sessionStorage.removeItem('attemptSilentLogin');
                 loaded = true;
                 setLogoImage();


### PR DESCRIPTION
## Summary
- allow fetching session user via cookies when no token is supplied
- trigger session retrieval after silent OAuth window closes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: sh: 1: vitest: not found)*
- `npx --yes vitest --passWithNoTests` *(fails: Cannot find package '@sveltejs/kit')*
- `npm install` *(fails: ENETUNREACH connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68967d1a4610832f9ac99740c354038a