### PR TITLE
Forward OAuth hints for silent login

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -162,14 +162,25 @@ Modification Log:
                await checkOauthCallback();
 
               const providerParam = querystringValue('provider');
-              const providers = providerParam !== null
-                      ? [providerParam]
-                      : Object.keys($config?.oauth?.providers ?? {});
+               const providers = providerParam !== null
+                       ? [providerParam]
+                       : Object.keys($config?.oauth?.providers ?? {});
 
                for (const provider of providers) {
                        console.log('Attempting silent login for provider:', provider);
+                       const providerConfig = $config?.oauth?.providers?.[provider];
+                       const params = new URLSearchParams();
+                       if (providerConfig?.login_hint) {
+                               params.set('login_hint', providerConfig.login_hint);
+                       }
+                       if (providerConfig?.domain_hint) {
+                               params.set('domain_hint', providerConfig.domain_hint);
+                       }
+
                        const silentAuthWindow = window.open(
-                               `${WEBUI_BASE_URL}/oauth/${provider}/silent-login`,
+                               `${WEBUI_BASE_URL}/oauth/${provider}/silent-login${
+                                       params.toString() ? `?${params.toString()}` : ''
+                               }`,
                                'silent-auth',
                                'width=1,height=1,left=-1000,top=-1000'
                        );


### PR DESCRIPTION
## Summary
- pass optional `login_hint` and `domain_hint` values during silent OAuth logins
- propagate these hint parameters through the backend OAuth manager

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689681f5d23c832f8872d84246588bb7