### PR TITLE
Add splash screen title and animations

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -249,13 +249,20 @@
                 font-size: 2rem;
                 font-weight: 500;
                 opacity: 0;
-                animation: app-name-in 0.6s ease-out forwards;
-                color: #000;
+                color: #ef4444;
+                animation:
+                        app-name-in 0.6s ease-out forwards,
+                        app-name-color 4s ease-in-out 0.6s infinite alternate;
         }
 
-        html.dark .app-name,
-        html.her .app-name {
-                color: #fff;
+        @keyframes app-name-color {
+                from {
+                        color: #ef4444;
+                }
+
+                to {
+                        color: #3b82f6;
+                }
         }
 
         @keyframes app-name-in {

--- a/src/app.html
+++ b/src/app.html
@@ -135,12 +135,14 @@
 					left: 50%;
 					transform: translateX(-50%);
 				"
-				src="/static/splash.png"
-			/>
+                                src="/static/splash.png"
+                        />
 
-			<div
-				style="
-					position: absolute;
+                        <h1 class="app-name">Scout</h1>
+
+                        <div
+                                style="
+                                        position: absolute;
 					top: 33%;
 					left: 50%;
 
@@ -235,13 +237,52 @@
 		display: block;
 	}
 
-	html.her #progress-bar {
-		display: block;
-	}
+        html.her #progress-bar {
+                display: block;
+        }
 
-	@media (max-width: 24rem) {
-		html.her #progress-background {
-			display: none;
+        .app-name {
+                position: absolute;
+                top: calc(44% + 7rem);
+                left: 50%;
+                transform: translate(-50%, 0);
+                font-size: 2rem;
+                font-weight: 500;
+                opacity: 0;
+                animation: app-name-in 0.6s ease-out forwards;
+                color: #000;
+        }
+
+        html.dark .app-name,
+        html.her .app-name {
+                color: #fff;
+        }
+
+        @keyframes app-name-in {
+                from {
+                        opacity: 0;
+                        transform: translate(-50%, 10px);
+                }
+
+                to {
+                        opacity: 1;
+                        transform: translate(-50%, 0);
+                }
+        }
+
+        #splash-screen.splash-exit {
+                animation: splash-fade-out 0.5s forwards;
+        }
+
+        @keyframes splash-fade-out {
+                to {
+                        opacity: 0;
+                }
+        }
+
+        @media (max-width: 24rem) {
+                html.her #progress-background {
+                        display: none;
 		}
 
 		html.her #progress-bar {

--- a/src/app.html
+++ b/src/app.html
@@ -138,7 +138,7 @@
                                 src="/static/splash.png"
                         />
 
-                        <h1 class="app-name">Scout</h1>
+                        <h1 class="app-name"></h1>
 
                         <div
                                 style="
@@ -248,11 +248,17 @@
                 transform: translate(-50%, 0);
                 font-size: 2rem;
                 font-weight: 500;
+                text-align: center;
                 opacity: 0;
                 color: #ef4444;
                 animation:
                         app-name-in 0.6s ease-out forwards,
                         app-name-color 4s ease-in-out 0.6s infinite alternate;
+        }
+
+        .app-name::after {
+                content: "Scout";
+                animation: app-name-text 4s ease-in-out 0.6s infinite;
         }
 
         @keyframes app-name-color {
@@ -274,6 +280,28 @@
                 to {
                         opacity: 1;
                         transform: translate(-50%, 0);
+                }
+        }
+
+        @keyframes app-name-text {
+                0%, 45% {
+                        content: "Scout";
+                        opacity: 1;
+                }
+
+                50% {
+                        content: "Scout";
+                        opacity: 0;
+                }
+
+                55%, 95% {
+                        content: "AI";
+                        opacity: 1;
+                }
+
+                100% {
+                        content: "AI";
+                        opacity: 0;
                 }
         }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -567,12 +567,24 @@
 			await goto(`/error`);
 		}
 
-		await tick();
+                await tick();
 
-		if (
-			document.documentElement.classList.contains('her') &&
-			document.getElementById('progress-bar')
-		) {
+                const removeSplashScreen = () => {
+                        const splash = document.getElementById('splash-screen');
+                        if (splash) {
+                                splash.classList.add('splash-exit');
+                                splash.addEventListener(
+                                        'animationend',
+                                        () => splash.remove(),
+                                        { once: true }
+                                );
+                        }
+                };
+
+                if (
+                        document.documentElement.classList.contains('her') &&
+                        document.getElementById('progress-bar')
+                ) {
 			loadingProgress.subscribe((value) => {
 				const progressBar = document.getElementById('progress-bar');
 
@@ -581,9 +593,9 @@
 				}
 			});
 
-			await loadingProgress.set(100);
+                        await loadingProgress.set(100);
 
-			document.getElementById('splash-screen')?.remove();
+                        removeSplashScreen();
 
 			const audio = new Audio(`/audio/greeting.mp3`);
 			const playAudio = () => {
@@ -594,10 +606,10 @@
 			document.addEventListener('click', playAudio);
 
 			loaded = true;
-		} else {
-			document.getElementById('splash-screen')?.remove();
-			loaded = true;
-		}
+                } else {
+                        removeSplashScreen();
+                        loaded = true;
+                }
 
 		return () => {
 			window.removeEventListener('resize', onResize);


### PR DESCRIPTION
## Summary
- Show "Scout" name on splash screen with fade-in effect
- Fade out splash screen after load before removing

## Testing
- `npm run lint` *(fails: ESLint config missing, svelte-kit not found, pylint not found)*
- `npm run build` *(fails: Cannot find package 'pyodide')*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689683e80540832fb85029bdaf8871fa