### PR TITLE
feat: add security modal shortcut

### DIFF
--- a/src/lib/components/icons/ShieldCheck.svelte
+++ b/src/lib/components/icons/ShieldCheck.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+        export let className = 'size-4';
+        export let strokeWidth = '1.5';
+</script>
+
+<svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width={strokeWidth}
+        stroke="currentColor"
+        class={className}
+>
+        <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+        />
+</svg>

--- a/src/lib/components/layout/Help.svelte
+++ b/src/lib/components/layout/Help.svelte
@@ -3,38 +3,51 @@
 
 	const i18n = getContext('i18n');
 
-	import ShortcutsModal from '../chat/ShortcutsModal.svelte';
-	import Tooltip from '../common/Tooltip.svelte';
-	import HelpMenu from './Help/HelpMenu.svelte';
+        import ShortcutsModal from '../chat/ShortcutsModal.svelte';
+        import Tooltip from '../common/Tooltip.svelte';
+        import HelpMenu from './Help/HelpMenu.svelte';
+        import ShieldCheck from '../icons/ShieldCheck.svelte';
+        import { showSecuritymd } from '$lib/stores';
 
 	let showShortcuts = false;
 </script>
 
-<div class=" hidden lg:flex fixed bottom-0 right-0 px-1 py-1 z-20">
-	<button
-		id="show-shortcuts-button"
-		class="hidden"
-		on:click={() => {
-			showShortcuts = !showShortcuts;
-		}}
-	/>
+<div class=" hidden lg:flex fixed bottom-0 right-0 px-1 py-1 z-20 gap-1">
+        <button
+                id="show-shortcuts-button"
+                class="hidden"
+                on:click={() => {
+                        showShortcuts = !showShortcuts;
+                }}
+        />
 
-	<HelpMenu
-		showDocsHandler={() => {
-			showShortcuts = !showShortcuts;
-		}}
-		showShortcutsHandler={() => {
-			showShortcuts = !showShortcuts;
-		}}
-	>
-		<Tooltip content={$i18n.t('Help')} placement="left">
-			<button
-				class="text-gray-600 dark:text-gray-300 bg-gray-300/20 size-4 flex items-center justify-center text-[0.7rem] rounded-full"
-			>
-				?
-			</button>
-		</Tooltip>
-	</HelpMenu>
+        <Tooltip content={$i18n.t('Security')} placement="left">
+                <button
+                        class="text-gray-600 dark:text-gray-300 bg-gray-300/20 size-4 flex items-center justify-center rounded-full"
+                        on:click={() => {
+                                showSecuritymd.set(true);
+                        }}
+                >
+                        <ShieldCheck className="size-3" />
+                </button>
+        </Tooltip>
+
+        <HelpMenu
+                showDocsHandler={() => {
+                        showShortcuts = !showShortcuts;
+                }}
+                showShortcutsHandler={() => {
+                        showShortcuts = !showShortcuts;
+                }}
+        >
+                <Tooltip content={$i18n.t('Help')} placement="left">
+                        <button
+                                class="text-gray-600 dark:text-gray-300 bg-gray-300/20 size-4 flex items-center justify-center text-[0.7rem] rounded-full"
+                        >
+                                ?
+                        </button>
+                </Tooltip>
+        </HelpMenu>
 </div>
 
 <ShortcutsModal bind:show={showShortcuts} />


### PR DESCRIPTION
## Summary
- add button to open Security.md popup
- add ShieldCheck icon component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file, svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968d26f698832fad966db1efe54254