### PR TITLE
Remove confetti from SecurityModal

### DIFF
--- a/src/lib/components/SecurityModal.svelte
+++ b/src/lib/components/SecurityModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
         import { onMount, getContext, createEventDispatcher } from 'svelte';
-        import { Confetti } from 'svelte-confetti';
 
         import { WEBUI_NAME } from '$lib/stores';
 
@@ -31,7 +30,6 @@
 		<div class="flex justify-between items-start">
 			<div class="text-xl font-semibold">
 				{$i18n.t('Ameritas AI Application Security Policy')}				
-				<Confetti x={[-1, -0.25]} y={[0, 0.5]} />
 			</div>
                         <button
                                 class="self-center"


### PR DESCRIPTION
## Summary
- remove unused Confetti import from SecurityModal
- drop Confetti component from security modal header

## Testing
- `npm test` (fails: Missing script "test")
- `node node_modules/vitest/vitest.mjs --passWithNoTests` (fails: Failed to load url bits-ui)


------
https://chatgpt.com/codex/tasks/task_e_68968f642b38832fa30b158414309ee6