### PR TITLE
refactor: use alias for ShieldCheck icon

### DIFF
--- a/src/lib/components/layout/Help.svelte
+++ b/src/lib/components/layout/Help.svelte
@@ -6,7 +6,7 @@
         import ShortcutsModal from '../chat/ShortcutsModal.svelte';
         import Tooltip from '../common/Tooltip.svelte';
         import HelpMenu from './Help/HelpMenu.svelte';
-        import ShieldCheck from '../icons/ShieldCheck.svelte';
+        import ShieldCheck from '$lib/components/icons/ShieldCheck.svelte';
         import { showSecuritymd } from '$lib/stores';
 
 	let showShortcuts = false;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,16 +6,19 @@ const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
-	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter({
-			pages: 'build',
-			assets: 'build',
-			fallback: 'index.html'
-		})
-	},
+        kit: {
+                // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
+                // If your environment is not supported or you settled on a specific environment, switch out the adapter.
+                // See https://kit.svelte.dev/docs/adapters for more information about adapters.
+                adapter: adapter({
+                        pages: 'build',
+                        assets: 'build',
+                        fallback: 'index.html'
+                }),
+                alias: {
+                        $lib: 'src/lib'
+                }
+        },
 	vitePlugin: {
 		// inspector: {
 		// 	toggleKeyCombo: 'meta-shift', // Key combination to open the inspector

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,18 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true
-	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+        "compilerOptions": {
+                "allowJs": true,
+                "checkJs": true,
+                "esModuleInterop": true,
+                "forceConsistentCasingInFileNames": true,
+                "resolveJsonModule": true,
+                "skipLibCheck": true,
+                "sourceMap": true,
+                "strict": true,
+                "baseUrl": ".",
+                "paths": {
+                        "$lib": ["src/lib"],
+                        "$lib/*": ["src/lib/*"]
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- use `$lib` alias for ShieldCheck import
- configure `$lib` alias in Svelte and TypeScript configs

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm run build` *(fails: Cannot find package 'pyodide')*

------
https://chatgpt.com/codex/tasks/task_e_689697def16c832fa2304ec455dd1529