### PR TITLE
Add Google Sans font for app branding

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -19,9 +19,15 @@
 }
 
 @font-face {
-	font-family: 'InstrumentSerif';
-	src: url('/assets/fonts/InstrumentSerif-Regular.ttf');
-	font-display: swap;
+        font-family: 'InstrumentSerif';
+        src: url('/assets/fonts/InstrumentSerif-Regular.ttf');
+        font-display: swap;
+}
+
+@font-face {
+        font-family: 'Google Sans';
+        src: url('/assets/fonts/GoogleSans.woff2');
+        font-display: swap;
 }
 
 html {

--- a/src/app.html
+++ b/src/app.html
@@ -248,6 +248,7 @@
                 transform: translate(-50%, 0);
                 font-size: 2rem;
                 font-weight: 500;
+                font-family: "Google Sans", sans-serif;
                 text-align: center;
                 opacity: 0;
                 color: #ef4444;

--- a/static/assets/fonts/GoogleSans.woff2
+++ b/static/assets/fonts/GoogleSans.woff2
@@ -1,0 +1,1 @@
+Placeholder for Google Sans font. Replace with actual GoogleSans.woff2 binary.


### PR DESCRIPTION
## Summary
- add bundled Google Sans font placeholder
- apply Google Sans via new @font-face
- style splash screen title with Google Sans for consistency

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file; svelte-kit not found; pylint not found)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896a55d775c832fbe4db294ebc4afb9