### PR TITLE
Instant app-name switch

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -259,7 +259,7 @@
 
         .app-name::after {
                 content: "Scout";
-                animation: app-name-text 4s ease-in-out 0.6s infinite;
+                animation: app-name-text 0.001s steps(1, end) infinite;
         }
 
         @keyframes app-name-color {
@@ -285,24 +285,12 @@
         }
 
         @keyframes app-name-text {
-                0%, 45% {
+                0% {
                         content: "Scout";
-                        opacity: 1;
                 }
 
                 50% {
-                        content: "Scout";
-                        opacity: 0;
-                }
-
-                55%, 95% {
                         content: "AI";
-                        opacity: 1;
-                }
-
-                100% {
-                        content: "AI";
-                        opacity: 0;
                 }
         }
 


### PR DESCRIPTION
## Summary
- Flash app name by using a near-instantaneous `app-name-text` animation
- Replace lengthy keyframes with simple Scout/AI toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896b0d6952c832fac219ef483e8a472