### PR TITLE
Refine splash screen fonts and animations

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,8 +26,9 @@
 
 @font-face {
         font-family: 'Google Sans';
-        src: url('/assets/fonts/GoogleSansCode-SemiBold.ttf');
-        font-display: swap;
+       src: url('/assets/fonts/GoogleSansCode-Medium.ttf');
+       font-display: swap;
+       font-weight: 500;
 }
 
 html {

--- a/src/app.html
+++ b/src/app.html
@@ -259,10 +259,10 @@
 			app-name-color 4s ease-in-out 0.6s infinite alternate;
 	}
 
-	.app-name::after {
-		content: 'Scout';
-		animation: app-name-text 0.001s steps(1, end) infinite;
-	}
+        .app-name::after {
+                content: 'Scout';
+               animation: app-name-text 2s steps(1, end) infinite;
+        }
 
 	@keyframes app-name-color {
 		from {
@@ -296,9 +296,9 @@
 		}
 	}
 
-	#splash-screen.splash-exit {
-		animation: splash-fade-out 0.5s forwards;
-	}
+       #splash-screen.splash-exit {
+               animation: splash-fade-out 1s forwards;
+       }
 
 	@keyframes splash-fade-out {
 		to {


### PR DESCRIPTION
## Summary
- Swap Google Sans for a medium-weight local font and ensure matching weight usage
- Slow the splash title text cycle for visible "Scout"/"AI" alternation
- Ease splash screen fade-out with a longer animation

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install --no-save vitest@1.6.1` *(fails: ENETUNREACH)*
- `npm run lint:frontend` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfdcfd44832f880381006aea1e8c