### PR TITLE
Rename voice recording to Dictate and add translations

### DIFF
--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -549,7 +549,7 @@ import Sparkles from '../icons/Sparkles.svelte';
                                                                   {/if}
 
                                                                 {#if content === ''}
-                                                                        <Tooltip content={$i18n.t('Record voice')}>
+                                                                        <Tooltip content={$i18n.t('Dictate')}>
 										<button
 											id="voice-input-button"
 											class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
@@ -577,7 +577,7 @@ import Sparkles from '../icons/Sparkles.svelte';
 													toast.error($i18n.t('Permission denied when accessing microphone'));
 												}
 											}}
-											aria-label="Voice Input"
+											aria-label={$i18n.t('Dictate')}
 										>
 											<svg
 												xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1295,7 +1295,7 @@ import Spinner from '../common/Spinner.svelte';
                                                                                 {/if}
 
                                                                                 {#if !history.currentId || history.messages[history.currentId]?.done == true}
-                                                                                          <Tooltip content={$i18n.t('Record voice')}>
+                                                                                          <Tooltip content={$i18n.t('Dictate')}>
                                                                                                   <button
                                                                                                           id="voice-input-button"
                                                                                                         class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
@@ -1326,7 +1326,7 @@ import Spinner from '../common/Spinner.svelte';
 															toast.error($i18n.t('Permission denied when accessing microphone'));
 														}
 													}}
-													aria-label="Voice Input"
+													aria-label={$i18n.t('Dictate')}
 												>
 													<svg
 														xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -854,6 +854,7 @@
 	"Read Aloud": "أقراء لي",
 	"Reasoning Effort": "",
 	"Record voice": "سجل صوت",
+	"Dictate": "سجل صوت",
 	"Redirecting you to Scout Community": "OpenWebUI إعادة توجيهك إلى مجتمع ",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -854,6 +854,7 @@
 	"Read Aloud": "Прочети на глас",
 	"Reasoning Effort": "Усилие за разсъждение",
 	"Record voice": "Записване на глас",
+	"Dictate": "Записване на глас",
 	"Redirecting you to Scout Community": "Пренасочване към Scout общността",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Отнасяйте се към себе си като \"Потребител\" (напр. \"Потребителят учи испански\")",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "পড়াশোনা করুন",
 	"Reasoning Effort": "",
 	"Record voice": "ভয়েস রেকর্ড করুন",
+	"Dictate": "ভয়েস রেকর্ড করুন",
 	"Redirecting you to Scout Community": "আপনাকে OpenWebUI কমিউনিটিতে পাঠানো হচ্ছে",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -854,6 +854,7 @@
 	"Read Aloud": "Llegir en veu alta",
 	"Reasoning Effort": "Esforç de raonament",
 	"Record voice": "Enregistrar la veu",
+	"Dictate": "Enregistrar la veu",
 	"Redirecting you to Scout Community": "Redirigint-te a la comunitat OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "Redueix la probabilitat de generar ximpleries. Un valor més alt (p. ex. 100) donarà respostes més diverses, mentre que un valor més baix (p. ex. 10) serà més conservador.",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Fes referència a tu mateix com a \"Usuari\" (p. ex., \"L'usuari està aprenent espanyol\")",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -854,6 +854,7 @@
 	"Read Aloud": "",
 	"Reasoning Effort": "",
 	"Record voice": "Irekord ang tingog",
+	"Dictate": "Irekord ang tingog",
 	"Redirecting you to Scout Community": "Gi-redirect ka sa komunidad sa OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Číst nahlas",
 	"Reasoning Effort": "",
 	"Record voice": "Nahrát hlas",
+	"Dictate": "Nahrát hlas",
 	"Redirecting you to Scout Community": "Přesměrování na komunitu Scout",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Odkazujte na sebe jako na \"uživatele\" (např. \"Uživatel se učí španělsky\").",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Læs højt",
 	"Reasoning Effort": "",
 	"Record voice": "Optag stemme",
+	"Dictate": "Optag stemme",
 	"Redirecting you to Open WebUI Community": "Omdirigerer dig til OpenWebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Referer til dig selv som \"Bruger\" (f.eks. \"Bruger lærer spansk\")",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Vorlesen",
 	"Reasoning Effort": "Schlussfolgerungsaufwand",
 	"Record voice": "Stimme aufnehmen",
+	"Dictate": "Stimme aufnehmen",
 	"Redirecting you to Open WebUI Community": "Sie werden zur OpenWebUI-Community weitergeleitet",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Beziehen Sie sich auf sich selbst als \"Benutzer\" (z. B. \"Benutzer lernt Spanisch\")",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "",
 	"Reasoning Effort": "",
 	"Record voice": "Record Bark",
+	"Dictate": "Record Bark",
 	"Redirecting you to Open WebUI Community": "Redirecting you to Open WebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Ανάγνωση Φωναχτά",
 	"Reasoning Effort": "",
 	"Record voice": "Εγγραφή φωνής",
+	"Dictate": "Εγγραφή φωνής",
 	"Redirecting you to Open WebUI Community": "Μετακατεύθυνση στην Κοινότητα OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Αναφέρεστε στον εαυτό σας ως \"User\" (π.χ., \"User μαθαίνει Ισπανικά\")",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "",
 	"Reasoning Effort": "",
 	"Record voice": "",
+	"Dictate": "",
 	"Redirecting you to Open WebUI Community": "",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "",
 	"Reasoning Effort": "",
 	"Record voice": "",
+	"Dictate": "",
 	"Redirecting you to Open WebUI Community": "",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Leer en voz alta",
 	"Reasoning Effort": "Esfuerzo del Razonamiento",
 	"Record voice": "Grabar voz",
+	"Dictate": "Grabar voz",
 	"Redirecting you to Open WebUI Community": "Redireccionando a la Comunidad Open-WebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "Reduce la probabilidad de generación sin sentido. Un valor más alto (p.ej. 100) dará respuestas más diversas, mientras que un valor más bajo (p.ej. 10) será más conservador.",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Referir a ti mismo como \"Usuario\" (p.ej. \"Usuario está aprendiendo Español\")",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Loe valjult",
 	"Reasoning Effort": "Arutluspingutus",
 	"Record voice": "Salvesta hääl",
+	"Dictate": "Salvesta hääl",
 	"Redirecting you to Open WebUI Community": "Suunamine Open WebUI kogukonda",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "Vähendab mõttetuste genereerimise tõenäosust. Kõrgem väärtus (nt 100) annab mitmekesisemaid vastuseid, samas kui madalam väärtus (nt 10) on konservatiivsem.",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Viita endale kui \"Kasutaja\" (nt \"Kasutaja õpib hispaania keelt\")",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Irakurri ozen",
 	"Reasoning Effort": "",
 	"Record voice": "Grabatu ahotsa",
+	"Dictate": "Grabatu ahotsa",
 	"Redirecting you to Open WebUI Community": "OpenWebUI Komunitatera berbideratzen",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Egin erreferentzia zure buruari \"Erabiltzaile\" gisa (adib., \"Erabiltzailea gaztelania ikasten ari da\")",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "خواندن به صورت صوتی",
 	"Reasoning Effort": "",
 	"Record voice": "ضبط صدا",
+	"Dictate": "ضبط صدا",
 	"Redirecting you to Open WebUI Community": "در حال هدایت به OpenWebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Lue ääneen",
 	"Reasoning Effort": "",
 	"Record voice": "Nauhoita ääntä",
+	"Dictate": "Nauhoita ääntä",
 	"Redirecting you to Open WebUI Community": "Ohjataan sinut OpenWebUI-yhteisöön",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Viittaa itseen \"Käyttäjänä\" (esim. \"Käyttäjä opiskelee espanjaa\")",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Lire à haute voix",
 	"Reasoning Effort": "",
 	"Record voice": "Enregistrer la voix",
+	"Dictate": "Enregistrer la voix",
 	"Redirecting you to Open WebUI Community": "Redirection vers la communauté OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Désignez-vous comme « Utilisateur » (par ex. « L'utilisateur apprend l'espagnol »)",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Lire à haute voix",
 	"Reasoning Effort": "Effort de raisonnement",
 	"Record voice": "Enregistrer la voix",
+	"Dictate": "Enregistrer la voix",
 	"Redirecting you to Open WebUI Community": "Redirection vers la communauté OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Désignez-vous comme « Utilisateur » (par ex. « L'utilisateur apprend l'espagnol »)",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -826,6 +826,7 @@
 	"Read Aloud": "Ler en voz alta",
 	"Reasoning Effort": "Esfuerzo de razonamiento",
 	"Record voice": "Grabar voz",
+	"Dictate": "Grabar voz",
 	"Redirecting you to Open WebUI Community": "Redireccionándote a a comunidad OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Referirse a vostede mismo como \"Usuario\" (por Exemplo, \"O usuario está aprendiendo Español\")",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "קרא בקול",
 	"Reasoning Effort": "",
 	"Record voice": "הקלט קול",
+	"Dictate": "הקלט קול",
 	"Redirecting you to Open WebUI Community": "מפנה אותך לקהילת OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "जोर से पढ़ें",
 	"Reasoning Effort": "",
 	"Record voice": "आवाज रिकॉर्ड करना",
+	"Dictate": "आवाज रिकॉर्ड करना",
 	"Redirecting you to Open WebUI Community": "आपको OpenWebUI समुदाय पर पुनर्निर्देशित किया जा रहा है",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Čitaj naglas",
 	"Reasoning Effort": "",
 	"Record voice": "Snimanje glasa",
+	"Dictate": "Snimanje glasa",
 	"Redirecting you to Open WebUI Community": "Preusmjeravanje na OpenWebUI zajednicu",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Nazivajte se \"Korisnik\" (npr. \"Korisnik uči španjolski\")",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Felolvasás",
 	"Reasoning Effort": "",
 	"Record voice": "Hang rögzítése",
+	"Dictate": "Hang rögzítése",
 	"Redirecting you to Open WebUI Community": "Átirányítás az OpenWebUI közösséghez",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Hivatkozzon magára \"Felhasználó\"-ként (pl. \"A Felhasználó spanyolul tanul\")",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Baca dengan Keras",
 	"Reasoning Effort": "",
 	"Record voice": "Rekam suara",
+	"Dictate": "Rekam suara",
 	"Redirecting you to Open WebUI Community": "Mengarahkan Anda ke Komunitas OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Merujuk diri Anda sebagai \"Pengguna\" (misalnya, \"Pengguna sedang belajar bahasa Spanyol\")",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Léigh Ard",
 	"Reasoning Effort": "Iarracht Réasúnúcháin",
 	"Record voice": "Taifead guth",
+	"Dictate": "Taifead guth",
 	"Redirecting you to Open WebUI Community": "Tú a atreorú chuig OpenWebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Tagairt duit féin mar \"Úsáideoir\" (m.sh., \"Tá an úsáideoir ag foghlaim Spáinnis\")",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Leggi ad alta voce",
 	"Reasoning Effort": "",
 	"Record voice": "Registra voce",
+	"Dictate": "Registra voce",
 	"Redirecting you to Open WebUI Community": "Reindirizzamento alla comunità OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "読み上げ",
 	"Reasoning Effort": "",
 	"Record voice": "音声を録音",
+	"Dictate": "音声を録音",
 	"Redirecting you to Open WebUI Community": "OpenWebUI コミュニティにリダイレクトしています",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "ხმამაღლა წაკითხვა",
 	"Reasoning Effort": "",
 	"Record voice": "ხმის ჩაწერა",
+	"Dictate": "ხმის ჩაწერა",
 	"Redirecting you to Open WebUI Community": "მიმდინარეობს გადამისამართება OpenWebUI-ის საზოგადოების საიტზე",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "읽어주기",
 	"Reasoning Effort": "",
 	"Record voice": "음성 녹음",
+	"Dictate": "음성 녹음",
 	"Redirecting you to Open WebUI Community": "OpenWebUI 커뮤니티로 리디렉션 중",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "스스로를 \"사용자\" 라고 지칭하세요. (예: \"사용자는 영어를 배우고 있습니다\")",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Skaityti garsiai",
 	"Reasoning Effort": "",
 	"Record voice": "Įrašyti balsą",
+	"Dictate": "Įrašyti balsą",
 	"Redirecting you to Open WebUI Community": "Perkeliam Jus į OpenWebUI bendruomenę",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Vadinkite save Naudotoju (pvz. Naudotojas mokosi prancūzų kalbos)",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Baca dengan lantang",
 	"Reasoning Effort": "",
 	"Record voice": "Rakam suara",
+	"Dictate": "Rakam suara",
 	"Redirecting you to Open WebUI Community": "Membawa anda ke Komuniti OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Rujuk diri anda sebagai \"User\" (cth, \"Pengguna sedang belajar bahasa Sepanyol\")",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Les høyt",
 	"Reasoning Effort": "Resonneringsinnsats",
 	"Record voice": "Ta opp tale",
+	"Dictate": "Ta opp tale",
 	"Redirecting you to Open WebUI Community": "Omdirigerer deg til OpenWebUI-fellesskapet",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Omtal deg selv som \"Bruker\" (f.eks. \"Bruker lærer spansk\")",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Voorlezen",
 	"Reasoning Effort": "",
 	"Record voice": "Neem stem op",
+	"Dictate": "Neem stem op",
 	"Redirecting you to Open WebUI Community": "Je wordt doorgestuurd naar OpenWebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Refereer naar jezelf als \"user\" (bv. \"User is Spaans aan het leren\"",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "ਜੋਰ ਨਾਲ ਪੜ੍ਹੋ",
 	"Reasoning Effort": "",
 	"Record voice": "ਆਵਾਜ਼ ਰਿਕਾਰਡ ਕਰੋ",
+	"Dictate": "ਆਵਾਜ਼ ਰਿਕਾਰਡ ਕਰੋ",
 	"Redirecting you to Open WebUI Community": "ਤੁਹਾਨੂੰ ਓਪਨਵੈਬਯੂਆਈ ਕਮਿਊਨਿਟੀ ਵੱਲ ਰੀਡਾਇਰੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Czytaj na głos",
 	"Reasoning Effort": "Wysiłek rozumowania",
 	"Record voice": "Nagraj swój głos",
+	"Dictate": "Nagraj swój głos",
 	"Redirecting you to Open WebUI Community": "Przekierowujemy Cię do społeczności Open WebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Odnosić się do siebie jako \"Użytkownik\" (np. \"Użytkownik uczy się hiszpańskiego\")",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Ler em Voz Alta",
 	"Reasoning Effort": "",
 	"Record voice": "Gravar voz",
+	"Dictate": "Gravar voz",
 	"Redirecting you to Open WebUI Community": "Redirecionando você para a Comunidade OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Refira-se como \"Usuário\" (por exemplo, \"Usuário está aprendendo espanhol\")",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Ler em Voz Alta",
 	"Reasoning Effort": "",
 	"Record voice": "Gravar voz",
+	"Dictate": "Gravar voz",
 	"Redirecting you to Open WebUI Community": "Redirecionando-o para a Comunidade OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Refera-se a si próprio como \"User\" (por exemplo, \"User está a aprender Espanhol\")",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Citește cu Voce Tare",
 	"Reasoning Effort": "",
 	"Record voice": "Înregistrează vocea",
+	"Dictate": "Înregistrează vocea",
 	"Redirecting you to Open WebUI Community": "Vă redirecționăm către Comunitatea OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Referiți-vă la dvs. ca \"Utilizator\" (de ex., \"Utilizatorul învață spaniolă\")",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Прочитать вслух",
 	"Reasoning Effort": "Усилие рассуждения",
 	"Record voice": "Записать голос",
+	"Dictate": "Записать голос",
 	"Redirecting you to Open WebUI Community": "Перенаправляем вас в сообщество OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "Снижает вероятность появления бессмыслицы. Большее значение (например, 100) даст более разнообразные ответы, в то время как меньшее значение (например, 10) будет более консервативным.",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Называйте себя \"User\" (например, \"User is learning Spanish\").",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Čítať nahlas",
 	"Reasoning Effort": "",
 	"Record voice": "Nahrať hlas",
+	"Dictate": "Nahrať hlas",
 	"Redirecting you to Open WebUI Community": "Presmerovanie na komunitu OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Odkazujte na seba ako na \"užívateľa\" (napr. \"Užívateľ sa učí španielsky\").",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Прочитај наглас",
 	"Reasoning Effort": "Јачина размишљања",
 	"Record voice": "Сними глас",
+	"Dictate": "Сними глас",
 	"Redirecting you to Open WebUI Community": "Преусмеравање на OpenWebUI заједницу",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Läs igenom",
 	"Reasoning Effort": "",
 	"Record voice": "Spela in röst",
+	"Dictate": "Spela in röst",
 	"Redirecting you to Open WebUI Community": "Omdirigerar dig till OpenWebUI Community",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Referera till dig själv som \"Användare\" (t.ex. \"Användaren lär sig spanska\")",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "อ่านออกเสียง",
 	"Reasoning Effort": "",
 	"Record voice": "บันทึกเสียง",
+	"Dictate": "บันทึกเสียง",
 	"Redirecting you to Open WebUI Community": "กำลังเปลี่ยนเส้นทางคุณไปยังชุมชน OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "เรียกตัวเองว่า \"ผู้ใช้\" (เช่น \"ผู้ใช้กำลังเรียนภาษาสเปน\")",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -719,5 +719,6 @@
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
         "Prompt Optimization Prompt Template": "",
-        "Tools": ""
+        "Tools": "",
+"Dictate": ""
 }

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "",
 	"Reasoning Effort": "",
 	"Record voice": "",
+	"Dictate": "",
 	"Redirecting you to Open WebUI Community": "",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Sesli Oku",
 	"Reasoning Effort": "",
 	"Record voice": "Ses kaydı yap",
+	"Dictate": "Ses kaydı yap",
 	"Redirecting you to Open WebUI Community": "OpenWebUI Topluluğuna yönlendiriliyorsunuz",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Kendinizden \"User\" olarak bahsedin (örneğin, \"User İspanyolca öğreniyor\")",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Читати вголос",
 	"Reasoning Effort": "Зусилля на міркування",
 	"Record voice": "Записати голос",
+	"Dictate": "Записати голос",
 	"Redirecting you to Open WebUI Community": "Перенаправляємо вас до спільноти OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "Зменшує ймовірність генерування нісенітниць. Вищий показник (напр., 100) забезпечить більше різноманітних відповідей, тоді як нижчий показник (напр., 10) буде більш обережним.",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Називайте себе \"Користувач\" (напр., \"Користувач вивчає іспанську мову\")",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "بُلند آواز میں پڑھیں",
 	"Reasoning Effort": "",
 	"Record voice": "صوت ریکارڈ کریں",
+	"Dictate": "صوت ریکارڈ کریں",
 	"Redirecting you to Open WebUI Community": "آپ کو اوپن ویب یو آئی کمیونٹی کی طرف ری ڈائریکٹ کیا جا رہا ہے",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "خود کو \"صارف\" کے طور پر حوالہ دیں (جیسے، \"صارف ہسپانوی سیکھ رہا ہے\")",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "Đọc ra loa",
 	"Reasoning Effort": "",
 	"Record voice": "Ghi âm",
+	"Dictate": "Ghi âm",
 	"Redirecting you to Open WebUI Community": "Đang chuyển hướng bạn đến Cộng đồng OpenWebUI",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "Hãy coi bản thân mình như \"Người dùng\" (ví dụ: \"Người dùng đang học Tiếng Tây Ban Nha\")",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "朗读",
 	"Reasoning Effort": "推理努力",
 	"Record voice": "录音",
+	"Dictate": "录音",
 	"Redirecting you to Open WebUI Community": "正在将您重定向到 OpenWebUI 社区",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "降低生成无意义内容的概率。较高的值（如100）将产生更多样化的回答，而较低的值（如10）则更加保守。",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "使用\"User\" (用户) 来指代自己（例如：“User 正在学习西班牙语”）",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -855,6 +855,7 @@
 	"Read Aloud": "大聲朗讀",
 	"Reasoning Effort": "推理程度",
 	"Record voice": "錄音",
+	"Dictate": "錄音",
 	"Redirecting you to Open WebUI Community": "正在將您重導向至 OpenWebUI 社群",
 	"Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.": "降低產生無意義內容的機率。較高的值（例如 100）會產生更多樣化的答案，而較低的值（例如 10）會更保守。",
 	"Refer to yourself as \"User\" (e.g., \"User is learning Spanish\")": "以「使用者」稱呼自己（例如：「使用者正在學習西班牙文」）",


### PR DESCRIPTION
## Summary
- Change voice input tooltip/aria labels from "Record voice" to "Dictate"
- Add `Dictate` translation key to all locales

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint config not found and pylint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689715184968832fb955d69f15f4a790