### PR TITLE
feat: add voice mode translation key

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1346,7 +1346,7 @@ import Spinner from '../common/Spinner.svelte';
                                                                                 {#if !history.currentId || history.messages[history.currentId]?.done == true}
                                                                                         {#if prompt === '' && files.length === 0}
                                                                                                 <div class=" flex items-center">
-													<Tooltip content={$i18n.t('Call')}>
+													<Tooltip content={$i18n.t('Use Voice Mode')}>
 														<button
 															class=" {webSearchEnabled ||
 															($settings?.webSearch ?? false) === 'always'
@@ -1405,7 +1405,7 @@ import Spinner from '../common/Spinner.svelte';
 																	);
 																}
 															}}
-															aria-label="Call"
+															aria-label="Use Voice Mode"
 														>
 															<Headphone className="size-5" />
 														</button>

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -1139,6 +1139,7 @@
 	"Use Gravatar": "Gravatar أستخدم",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Initials أستخدم",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (أولاما)",
 	"use_mmap (Ollama)": "use_mmap (أولاما)",
 	"user": "مستخدم",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -1139,6 +1139,7 @@
 	"Use Gravatar": "Използвайте Gravatar",
 	"Use groups to group your users and assign permissions.": "Използвайте групи, за да групирате вашите потребители и да присвоите разрешения.",
 	"Use Initials": "Използвайте инициали",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "потребител",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar ব্যবহার করুন",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "নামের আদ্যক্ষর ব্যবহার করুন",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (ওলামা)",
 	"use_mmap (Ollama)": "use_mmap (ওলামা)",
 	"user": "ব্যবহারকারী",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -1139,6 +1139,7 @@
 	"Use Gravatar": "Utilitzar Gravatar",
 	"Use groups to group your users and assign permissions.": "Utilitza grups per agrupar els usuaris i assignar permisos.",
 	"Use Initials": "Utilitzar inicials",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "usuari",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -1139,6 +1139,7 @@
 	"Use Gravatar": "Paggamit sa Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "tiggamit",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Použití Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Použijte iniciály",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "uživatel",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Brug Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Brug initialer",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "bruger",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar verwenden",
 	"Use groups to group your users and assign permissions.": "Nutzen Sie Gruppen, um Ihre Benutzer zu gruppieren und Berechtigungen zuzuweisen.",
 	"Use Initials": "Initialen verwenden",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "Benutzer",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Use Gravatar much avatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Use Initials much initial",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "user much user",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Χρησιμοποιήστε Gravatar",
 	"Use groups to group your users and assign permissions.": "Χρησιμοποιήστε ομάδες για να ομαδοποιήσετε τους χρήστες σας και να αναθέσετε δικαιώματα.",
 	"Use Initials": "Χρησιμοποιήστε Αρχικά",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "user",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Usar Gravatar",
 	"Use groups to group your users and assign permissions.": "Usar grupos para agrupar a usuarios y asignar permisos.",
 	"Use Initials": "Usar Iniciales",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "usuario",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Kasuta Gravatari",
 	"Use groups to group your users and assign permissions.": "Kasutage gruppe oma kasutajate grupeerimiseks ja õiguste määramiseks.",
 	"Use Initials": "Kasuta initsiaale",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "kasutaja",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Erabili Gravatar",
 	"Use groups to group your users and assign permissions.": "Erabili taldeak zure erabiltzaileak taldekatu eta baimenak esleitzeko.",
 	"Use Initials": "Erabili inizialak",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "erabiltzailea",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "استفاده از گراواتار",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "استفاده از سرواژه",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (اولاما)",
 	"use_mmap (Ollama)": "use_mmap (اولاما)",
 	"user": "کاربر",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Käytä Gravataria",
 	"Use groups to group your users and assign permissions.": "Käytä ryhmiä jäsentääksesi käyttäjiä ja antaaksesi käyttöoikeuksia.",
 	"Use Initials": "Käytä alkukirjaimia",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "käyttäjä",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Utilisez Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Utiliser les initiales",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "utiliser mmap (Ollama)",
 	"user": "utilisateur",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Utiliser Gravatar",
 	"Use groups to group your users and assign permissions.": "Utilisez des groupes pour regrouper vos utilisateurs et attribuer des permissions.",
 	"Use Initials": "Utiliser les initiales",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "Utiliser mlock (Ollama)",
 	"use_mmap (Ollama)": "Utiliser mmap (Ollama)",
 	"user": "utilisateur",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -1106,6 +1106,7 @@
 	"Use Gravatar": "Usar Gravatar",
 	"Use groups to group your users and assign permissions.": "Use grupos para agrupar a sus usuarios y asignar permisos.",
 	"Use Initials": "Usar Iniciales",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "usuario",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "שימוש ב Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "שימוש ב initials",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (אולמה)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "משתמש",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar का प्रयोग करें",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "प्रथमाक्षर का प्रयोग करें",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (ओलामा)",
 	"use_mmap (Ollama)": "use_mmap (ओलामा)",
 	"user": "उपयोगकर्ता",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Koristi Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Koristi inicijale",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "korisnik",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar használata",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Monogram használata",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "felhasználó",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gunakan Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Gunakan Inisial",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "pengguna",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Úsáid Gravatar",
 	"Use groups to group your users and assign permissions.": "Úsáid grúpaí chun d'úsáideoirí a ghrúpáil agus ceadanna a shannadh",
 	"Use Initials": "Úsáid ceannlitreacha",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "úsáideoir",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Usa Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Usa iniziali",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "utente",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar を使用する",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "初期値を使用する",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "ユーザー",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar-ის გამოყენება",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "ინიციალების გამოყენება",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "მომხმარებელი",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar 사용",
 	"Use groups to group your users and assign permissions.": "그룹을 사용하여 사용자를 그룹화하고 권한을 할당하세요.",
 	"Use Initials": "초성 사용",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (올라마)",
 	"use_mmap (Ollama)": "use_mmap (올라마)",
 	"user": "사용자",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Naudoti Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Naudotojo inicialai",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "naudotojas",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gunakan Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Gunakan nama pendek",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "se_mmap (Ollama)",
 	"user": "pengguna",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Bruk Gravatar",
 	"Use groups to group your users and assign permissions.": "Bruk grupper til å samle brukere og tildele tillatelser.",
 	"Use Initials": "Bruk initialer",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "bruker",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gebruik Gravatar",
 	"Use groups to group your users and assign permissions.": "Gebruik groepen om gebruikers te groeperen en rechten aan te wijzen",
 	"Use Initials": "Gebruik initialen",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "user",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "ਗ੍ਰਾਵਾਟਾਰ ਵਰਤੋ",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "ਸ਼ੁਰੂਆਤੀ ਅੱਖਰ ਵਰਤੋ",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (ਓਲਾਮਾ)",
 	"use_mmap (Ollama)": "use_mmap (ਓਲਾਮਾ)",
 	"user": "ਉਪਭੋਗਤਾ",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Użyj Gravatara",
 	"Use groups to group your users and assign permissions.": "Wykorzystaj grupy do grupowania użytkowników i przypisywania uprawnień.",
 	"Use Initials": "Użyj inicjałów",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "użyj_mlock (Ollama)",
 	"use_mmap (Ollama)": "użyj_mmap (Ollama)",
 	"user": "użytkownik",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Usar Gravatar",
 	"Use groups to group your users and assign permissions.": "Use grupos para agrupar seus usuários e atribuir permissões.",
 	"Use Initials": "Usar Iniciais",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "usuário",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Usar Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Usar Iniciais",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "utilizador",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Folosește Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Folosește Inițialele",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "utilizator",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Использовать Gravatar",
 	"Use groups to group your users and assign permissions.": "Используйте группы, чтобы группировать пользователей и назначать разрешения.",
 	"Use Initials": "Использовать инициалы",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "пользователь",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Použiť Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Použiť iniciály",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "používateľ",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Користи Граватар",
 	"Use groups to group your users and assign permissions.": "Користите групе да бисте разврстали ваше кориснике и доделили овлашћења.",
 	"Use Initials": "Користи иницијале",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "корисник",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Använd Gravatar",
 	"Use groups to group your users and assign permissions.": "Använd grupper för att gruppera dina användare och tilldela behörigheter.",
 	"Use Initials": "Använd initialer",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "användare",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "ใช้ Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "ใช้ตัวย่อ",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "ผู้ใช้",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -720,5 +720,6 @@
         "Prompt Optimization Model": "",
         "Prompt Optimization Prompt Template": "",
         "Tools": "",
-"Dictate": ""
+"Dictate": "",
+        "Use Voice Mode": ""
 }

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "",
 	"use_mmap (Ollama)": "",
 	"user": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Gravatar Kullan",
 	"Use groups to group your users and assign permissions.": "Kullanıcılarınızı gruplamak ve izinler atamak için grupları kullanın.",
 	"Use Initials": "Baş Harfleri Kullan",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "kullanıcı",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Змінити аватар",
 	"Use groups to group your users and assign permissions.": "Використовуйте групи, щоб об’єднувати користувачів і призначати дозволи.",
 	"Use Initials": "Використовувати ініціали",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "користувач",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "گراویٹر استعمال کریں",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "ابتدائیات استعمال کریں",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "استعمال کریں_mlock (Ollama)",
 	"use_mmap (Ollama)": "استعمال_mmap (Ollama)",
 	"user": "صارف",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "Sử dụng Gravatar",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "Sử dụng tên viết tắt",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock (Ollama)",
 	"use_mmap (Ollama)": "use_mmap (Ollama)",
 	"user": "Người sử dụng",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "使用来自 Gravatar 的头像",
 	"Use groups to group your users and assign permissions.": "使用权限组来组织用户并分配权限。",
 	"Use Initials": "使用首个字符作为头像",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "use_mlock（Ollama）",
 	"use_mmap (Ollama)": "use_mmap （Ollama）",
 	"user": "用户",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -1140,6 +1140,7 @@
 	"Use Gravatar": "使用 Gravatar",
 	"Use groups to group your users and assign permissions.": "使用群組來組織您的使用者並分配權限。",
 	"Use Initials": "使用姓名縮寫",
+        "Use Voice Mode": "",
 	"use_mlock (Ollama)": "使用 mlock (Ollama)",
 	"use_mmap (Ollama)": "使用 mmap (Ollama)",
 	"user": "使用者",


### PR DESCRIPTION
## Summary
- rename call button tooltip/aria label to "Use Voice Mode"
- add "Use Voice Mode" translation key across locale files

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68971871f4a8832fa7fcebba8cc23a50