### PR TITLE
Use menu icon for chat tools button

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -47,6 +47,7 @@ import Spinner from '../common/Spinner.svelte';
         import GlobeAlt from '../icons/GlobeAlt.svelte';
         import CommandLine from '../icons/CommandLine.svelte';
         import WrenchSolid from '../icons/WrenchSolid.svelte';
+        import EllipsisVertical from '$lib/components/icons/EllipsisVertical.svelte';
         import Sparkles from '../icons/Sparkles.svelte';
         import { KokoroWorker } from '$lib/workers/KokoroWorker';
         import ToolServersModal from './ToolServersModal.svelte';
@@ -1181,7 +1182,7 @@ import Spinner from '../common/Spinner.svelte';
                                                                                                 type="button"
                                                                                                 aria-label="Tools"
                                                                                         >
-                                                                                                <WrenchSolid className="size-5" />
+                                                                                                <EllipsisVertical className="size-5" />
                                                                                         </button>
                                                                                 </ToolsMenu>
 

--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -10,6 +10,7 @@
     import Tooltip from '$lib/components/common/Tooltip.svelte';
 
     import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
+    import EllipsisVertical from '$lib/components/icons/EllipsisVertical.svelte';
     import GlobeAltSolid from '$lib/components/icons/GlobeAltSolid.svelte';
     import CommandLineSolid from '$lib/components/icons/CommandLineSolid.svelte';
     import PhotoSolid from '$lib/components/icons/PhotoSolid.svelte';
@@ -74,7 +75,7 @@
                         class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
                     >
                         <div class="flex gap-2 items-center">
-                            <WrenchSolid />
+                            <EllipsisVertical />
                             <div>{$i18n.t('Tools')}</div>
                         </div>
                     </DropdownMenu.SubTrigger>


### PR DESCRIPTION
## Summary
- replace wrench icon in chat message input with a menu icon
- use the same menu icon in the tools dropdown trigger

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68971c8f1ddc832fb239bdbbe7016638