### PR TITLE
Improve model configuration error handling

### DIFF
--- a/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
@@ -80,24 +80,24 @@
 		sortKey = '';
 		sortOrder = '';
 	};
-	const submitHandler = async () => {
-		loading = true;
+        const submitHandler = async () => {
+                loading = true;
 
-		const res = await setModelsConfig(localStorage.token, {
-			DEFAULT_MODELS: defaultModelIds.join(','),
-			MODEL_ORDER_LIST: modelIds
-		});
+                try {
+                        await setModelsConfig(localStorage.token, {
+                                DEFAULT_MODELS: defaultModelIds.join(','),
+                                MODEL_ORDER_LIST: modelIds
+                        });
 
-		if (res) {
-			toast.success($i18n.t('Models configuration saved successfully'));
-			initHandler();
-			show = false;
-		} else {
-			toast.error($i18n.t('Failed to save models configuration'));
-		}
-
-		loading = false;
-	};
+                        toast.success($i18n.t('Models configuration saved successfully'));
+                        initHandler();
+                        show = false;
+                } catch (error) {
+                        toast.error($i18n.t('Failed to save models configuration'));
+                } finally {
+                        loading = false;
+                }
+        };
 
 	onMount(async () => {
 		init();


### PR DESCRIPTION
## Summary
- wrap models configuration submission with try/catch/finally
- show success toast and close modal on success, error toast on failure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm install vitest` *(fails: AggregateError ENETUNREACH)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689737fcb9a0832fb01eaf2669c75fee