### PR TITLE
feat: use unique label for tools submenu

### DIFF
--- a/src/lib/components/chat/MessageInput/ToolsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.svelte
@@ -75,7 +75,7 @@
                     >
                         <div class="flex gap-2 items-center">
                             <WrenchSolid />
-                            <div>{$i18n.t('Tools')}</div>
+                            <div>{$i18n.t('Select Tools')}</div>
                         </div>
                     </DropdownMenu.SubTrigger>
                     <DropdownMenu.SubContent

--- a/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
+++ b/src/lib/components/chat/MessageInput/ToolsMenu.test.ts
@@ -48,7 +48,7 @@ describe('ToolsMenu', () => {
         await fireEvent.click(getByText('open'));
         await tick();
 
-        await fireEvent.click(getByText('Tools'));
+        await fireEvent.click(getByText('Select Tools'));
         await tick();
         await fireEvent.click(getByText('Test Tool'));
         const selectedToolIds = component.$$.ctx[component.$$.props['selectedToolIds']];

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -1216,5 +1216,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -1216,5 +1216,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -1217,5 +1217,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -1216,5 +1216,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -1216,5 +1216,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -1217,5 +1217,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1219,5 +1219,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -1181,5 +1181,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -719,5 +719,6 @@
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
         "Prompt Optimization Prompt Template": "",
-        "Tools": ""
+        "Tools": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -1218,5 +1218,6 @@
         "Prompt Optimization": "",
         "Enable Prompt Optimization": "",
         "Prompt Optimization Model": "",
-        "Prompt Optimization Prompt Template": ""
+        "Prompt Optimization Prompt Template": "",
+        "Select Tools": ""
 }


### PR DESCRIPTION
## Summary
- rename chat tools submenu to "Select Tools" so dropdown and tooltip use separate i18n keys
- add "Select Tools" translation key to all locale files
- update tests to open submenu via the new label

## Testing
- `npm run build` *(fails: Failed to load micropip package)*
- `npm run test:frontend` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689734a05b04832f95170d6806a242a3