### PR TITLE
Validate non-empty chat input

### DIFF
--- a/src/lib/apis/channels/index.ts
+++ b/src/lib/apis/channels/index.ts
@@ -248,14 +248,16 @@ export const getChannelThreadMessages = async (
 };
 
 type MessageForm = {
-	parent_id?: string;
-	content: string;
-	data?: object;
-	meta?: object;
+       parent_id?: string;
+       // content is assumed to be a validated, non-empty string
+       content: string;
+       data?: object;
+       meta?: object;
 };
 
 export const sendMessage = async (token: string = '', channel_id: string, message: MessageForm) => {
-	let error = null;
+       // message.content is expected to be non-empty and already validated by the caller
+       let error = null;
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/channels/${channel_id}/messages/post`, {
 		method: 'POST',

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -151,13 +151,23 @@ import Spinner from '../common/Spinner.svelte';
 		(model) => $models.find((m) => m.id === model)?.info?.meta?.capabilities?.vision ?? true
 	);
 
-	const scrollToBottom = () => {
-		const element = document.getElementById('messages-container');
-		element.scrollTo({
-			top: element.scrollHeight,
-			behavior: 'smooth'
-		});
-	};
+        const scrollToBottom = () => {
+                const element = document.getElementById('messages-container');
+                element.scrollTo({
+                        top: element.scrollHeight,
+                        behavior: 'smooth'
+                });
+        };
+
+       const submitPrompt = () => {
+               const text = prompt.trim();
+               if (text.length === 0) {
+                       toast.warning($i18n.t('Please enter a message.'));
+                       return;
+               }
+               prompt = text;
+               dispatch('submit', prompt);
+       };
 
 	const screenCaptureHandler = async () => {
 		try {
@@ -561,19 +571,19 @@ import Spinner from '../common/Spinner.svelte';
 								await tick();
 								document.getElementById('chat-input')?.focus();
 
-								if ($settings?.speechAutoSend ?? false) {
-									dispatch('submit', prompt);
-								}
-							}}
-						/>
-					{:else}
-						<form
-							class="w-full flex gap-1.5"
-							on:submit|preventDefault={() => {
-								// check if selectedModels support image input
-								dispatch('submit', prompt);
-							}}
-						>
+                                                               if ($settings?.speechAutoSend ?? false) {
+                                                                       submitPrompt();
+                                                               }
+                                                        }}
+                                                />
+                                        {:else}
+                                                <form
+                                                        class="w-full flex gap-1.5"
+                                                       on:submit|preventDefault={() => {
+                                                               // check if selectedModels support image input
+                                                               submitPrompt();
+                                                       }}
+                                                >
 							<div
 								class="flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border border-gray-100 dark:border-gray-850 hover:border-gray-200 focus-within:border-gray-200 hover:dark:border-gray-800 focus-within:dark:border-gray-800 transition px-1 bg-white/90 dark:bg-gray-400/5 dark:text-gray-100"
 								dir={$settings?.chatDirection ?? 'LTR'}
@@ -823,12 +833,10 @@ import Spinner from '../common/Spinner.svelte';
 																	? (e.key === 'Enter' || e.keyCode === 13) && isCtrlPressed
 																	: (e.key === 'Enter' || e.keyCode === 13) && !e.shiftKey;
 
-															if (enterPressed) {
-																e.preventDefault();
-																if (prompt !== '' || files.length > 0) {
-																	dispatch('submit', prompt);
-																}
-															}
+                                                       if (enterPressed) {
+                                                               e.preventDefault();
+                                                               submitPrompt();
+                                                       }
 														}
 													}
 
@@ -1005,14 +1013,10 @@ import Spinner from '../common/Spinner.svelte';
 
 														console.log('Enter pressed:', enterPressed);
 
-														if (enterPressed) {
-															e.preventDefault();
-														}
-
-														// Submit the prompt when Enter key is pressed
-														if ((prompt !== '' || files.length > 0) && enterPressed) {
-															dispatch('submit', prompt);
-														}
+                                               if (enterPressed) {
+                                                       e.preventDefault();
+                                                       submitPrompt();
+                                               }
 													}
 												}
 


### PR DESCRIPTION
## Summary
- prevent empty chat submissions by trimming input and warning users
- call validated submit helper throughout MessageInput
- note API channel messages expect pre-validated content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:frontend` (fails: vitest: not found)
- `npm install vitest` (fails: connect ENETUNREACH)
- `npm run lint` (fails: svelte-kit: not found)

------
https://chatgpt.com/codex/tasks/task_e_68973e04b510832fb59a7a784afad14f