### PR TITLE
feat: use explicit type for autocomplete requests

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -1,4 +1,4 @@
-import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
+import { WEBUI_API_BASE_URL, WEBUI_BASE_URL, AUTOCOMPLETE_TYPES } from '$lib/constants';
 import { convertOpenApiToToolPayload } from '$lib/utils';
 import { getOpenAIModelsDirect } from './openai';
 
@@ -725,11 +725,11 @@ export const generateQueries = async (
 };
 
 export const generateAutoCompletion = async (
-	token: string = '',
-	model: string,
-	prompt: string,
-	messages?: object[],
-	type: string = 'search query'
+        token: string = '',
+        model: string,
+        prompt: string,
+        messages?: object[],
+        type: string = AUTOCOMPLETE_TYPES.GENERAL
 ) => {
 	const controller = new AbortController();
 	let error = null;

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -27,7 +27,7 @@
         import { generateAutoCompletion, optimizePrompt } from '$lib/apis';
 	import { deleteFileById } from '$lib/apis/files';
 
-	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT, AUTOCOMPLETE_TYPES } from '$lib/constants';
 
         import InputMenu from './MessageInput/InputMenu.svelte';
         import ToolsMenu from './MessageInput/ToolsMenu.svelte';
@@ -703,14 +703,15 @@ import Spinner from '../common/Spinner.svelte';
 														toast.error($i18n.t('Please select a model first.'));
 													}
 
-													const res = await generateAutoCompletion(
-														localStorage.token,
-														selectedModelIds.at(0),
-														text,
-														history?.currentId
-															? createMessagesList(history, history.currentId)
-															: null
-													).catch((error) => {
+                                                                                                        const res = await generateAutoCompletion(
+                                                                                                                localStorage.token,
+                                                                                                                selectedModelIds.at(0),
+                                                                                                                text,
+                                                                                                                history?.currentId
+                                                                                                                        ? createMessagesList(history, history.currentId)
+                                                                                                                        : null,
+                                                                                                                AUTOCOMPLETE_TYPES.GENERAL
+                                                                                                        ).catch((error) => {
 														console.log(error);
 
 														return null;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,11 @@ export const WEBUI_VERSION = APP_VERSION;
 export const WEBUI_BUILD_HASH = APP_BUILD_HASH;
 export const REQUIRED_OLLAMA_VERSION = '0.1.16';
 
+export const AUTOCOMPLETE_TYPES = {
+        GENERAL: 'General',
+        SEARCH_QUERY: 'Search Query'
+} as const;
+
 export const SUPPORTED_FILE_TYPE = [
 	'application/epub+zip',
 	'application/pdf',


### PR DESCRIPTION
## Summary
- add AUTOCOMPLETE_TYPES constants and default to General
- send General type in chat input autocomplete requests

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_689746f9faa0832fb1f624518bd33fe7