### PR TITLE
Validate model config fields

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -276,10 +276,31 @@ class ModelsConfigForm(BaseModel):
 
 @router.get("/models", response_model=ModelsConfigForm)
 async def get_models_config(request: Request, user=Depends(get_admin_user)):
+    def _as_str(value):
+        if value is None:
+            return None
+        return value if isinstance(value, str) else str(value)
+
+    def _as_list_of_str(value):
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        if isinstance(value, str):
+            return [value]
+        try:
+            return [str(v) for v in list(value)]
+        except Exception:
+            return []
+
     return {
-        "DEFAULT_MODELS": request.app.state.config.DEFAULT_MODELS,
-        "MODEL_ORDER_LIST": request.app.state.config.MODEL_ORDER_LIST,
-        "MODEL_FALLBACK_PRIORITIES": request.app.state.config.MODEL_FALLBACK_PRIORITIES,
+        "DEFAULT_MODELS": _as_str(request.app.state.config.DEFAULT_MODELS),
+        "MODEL_ORDER_LIST": _as_list_of_str(
+            request.app.state.config.MODEL_ORDER_LIST
+        ),
+        "MODEL_FALLBACK_PRIORITIES": _as_str(
+            request.app.state.config.MODEL_FALLBACK_PRIORITIES
+        ),
     }
 
 

--- a/backend/open_webui/test/apps/webui/routers/test_configs.py
+++ b/backend/open_webui/test/apps/webui/routers/test_configs.py
@@ -1,0 +1,57 @@
+import sys
+from types import SimpleNamespace
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Provide stub modules to avoid heavy imports
+env_stub = SimpleNamespace(SRC_LOG_LEVELS={"CONFIG": "INFO"})
+config_stub = SimpleNamespace(
+    get_config=lambda: {},
+    save_config=lambda cfg: None,
+    BannerModel=object,
+)
+auth_stub = SimpleNamespace(get_admin_user=lambda: None, get_verified_user=lambda: None)
+
+sys.modules['open_webui.env'] = env_stub
+sys.modules['open_webui.config'] = config_stub
+sys.modules['open_webui.utils.auth'] = auth_stub
+
+from open_webui.routers.configs import router as configs_router
+
+
+@contextmanager
+def mock_admin(app: FastAPI):
+    def user():
+        return SimpleNamespace(role="admin")
+
+    app.dependency_overrides[auth_stub.get_admin_user] = user
+    try:
+        yield
+    finally:
+        app.dependency_overrides = {}
+
+
+def test_get_models_config_with_invalid_types():
+    app = FastAPI()
+    app.state.config = SimpleNamespace(
+        DEFAULT_MODELS=None,
+        MODEL_ORDER_LIST=[],
+        MODEL_FALLBACK_PRIORITIES=None,
+    )
+    app.include_router(configs_router)
+
+    with TestClient(app) as client:
+        app.state.config.DEFAULT_MODELS = 123
+        app.state.config.MODEL_ORDER_LIST = 123
+        app.state.config.MODEL_FALLBACK_PRIORITIES = ["a", 1]
+
+        with mock_admin(app):
+            response = client.get("/models")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["DEFAULT_MODELS"] == "123"
+        assert data["MODEL_ORDER_LIST"] == []
+        assert data["MODEL_FALLBACK_PRIORITIES"] == "['a', 1]"


### PR DESCRIPTION
## Summary
- sanitize models config values when retrieving the configuration
- add regression test covering invalid types in model config

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/apps/webui/routers/test_configs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689748f2908c832f9e713b7bf895acff