### PR TITLE
fix: stop button not submitting form

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1449,17 +1449,18 @@ import Spinner from '../common/Spinner.svelte';
 										{:else}
 											<div class=" flex items-center">
 												<Tooltip content={$i18n.t('Stop')}>
-													<button
-														class="bg-white hover:bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5"
-														on:click={() => {
-															stopResponse();
-														}}
-													>
-														<svg
-															xmlns="http://www.w3.org/2000/svg"
-															viewBox="0 0 24 24"
-															fill="currentColor"
-															class="size-5"
+                                                                                                        <button
+                                                                                                                class="bg-white hover:bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5"
+                                                                                                                type="button"
+                                                                                                                on:click={() => {
+                                                                                                                        stopResponse();
+                                                                                                                }}
+                                                                                                        >
+                                                                                                                <svg
+                                                                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                                                                        viewBox="0 0 24 24"
+                                                                                                                        fill="currentColor"
+                                                                                                                        class="size-5"
 														>
 															<path
 																fill-rule="evenodd"


### PR DESCRIPTION
## Summary
- prevent message form from submitting when the stop button is pressed by adding `type="button"`

## Testing
- `npm run test:frontend` (fails: vitest: not found)
- `npm install vitest --no-save` (fails: ENETUNREACH while installing onnxruntime-node)


------
https://chatgpt.com/codex/tasks/task_e_68974e9b6840832f86094c3bf45c1abf