### PR TITLE
feat: allow lists in models config

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -261,9 +261,9 @@ async def set_code_execution_config(
 # SetDefaultModels
 ############################
 class ModelsConfigForm(BaseModel):
-    DEFAULT_MODELS: Optional[str]
+    DEFAULT_MODELS: Optional[str | list[str]]
     MODEL_ORDER_LIST: Optional[list[str]]
-    MODEL_FALLBACK_PRIORITIES: Optional[str]
+    MODEL_FALLBACK_PRIORITIES: Optional[str | list[str]]
 
 
 @router.get("/models", response_model=ModelsConfigForm)

--- a/backend/open_webui/test/apps/webui/routers/test_configs_models.py
+++ b/backend/open_webui/test/apps/webui/routers/test_configs_models.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import types
+import sys
+
+from pydantic import BaseModel
+
+# Stub minimal modules to satisfy imports without requiring full app
+auth_module = types.ModuleType("open_webui.utils.auth")
+
+class DummyUser(BaseModel):
+    id: str = "1"
+    name: str = "Test"
+    email: str = "test@example.com"
+    role: str = "admin"
+
+
+async def get_admin_user():
+    return DummyUser()
+
+
+async def get_verified_user():
+    return DummyUser()
+
+
+auth_module.get_admin_user = get_admin_user
+auth_module.get_verified_user = get_verified_user
+sys.modules["open_webui.utils.auth"] = auth_module
+
+config_module = types.ModuleType("open_webui.config")
+
+
+def get_config():
+    return {}
+
+
+def save_config(config):
+    return config
+
+
+class BannerModel(BaseModel):
+    id: str
+    type: str
+    title: str | None = None
+    content: str = ""
+    dismissible: bool = True
+    timestamp: int = 0
+
+
+config_module.get_config = get_config
+config_module.save_config = save_config
+config_module.BannerModel = BannerModel
+sys.modules["open_webui.config"] = config_module
+
+env_module = types.ModuleType("open_webui.env")
+env_module.SRC_LOG_LEVELS = {"CONFIG": "INFO"}
+sys.modules["open_webui.env"] = env_module
+
+from open_webui.routers import configs as configs_router
+
+
+def create_app():
+    app = FastAPI()
+    app.include_router(configs_router.router, prefix="/configs")
+    app.state.config = SimpleNamespace(
+        DEFAULT_MODELS=None,
+        MODEL_ORDER_LIST=None,
+        MODEL_FALLBACK_PRIORITIES=None,
+    )
+    return app
+
+
+def test_set_models_config_with_list():
+    app = create_app()
+    client = TestClient(app)
+    payload = {
+        "DEFAULT_MODELS": ["m1", "m2"],
+        "MODEL_FALLBACK_PRIORITIES": ["m2", "m1"],
+        "MODEL_ORDER_LIST": ["m1", "m2"],
+    }
+    response = client.post("/configs/models", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["DEFAULT_MODELS"] == ["m1", "m2"]
+    assert data["MODEL_FALLBACK_PRIORITIES"] == ["m2", "m1"]
+
+    response = client.get("/configs/models")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["DEFAULT_MODELS"] == ["m1", "m2"]
+
+
+def test_set_models_config_with_string():
+    app = create_app()
+    client = TestClient(app)
+    payload = {
+        "DEFAULT_MODELS": "x,y",
+        "MODEL_FALLBACK_PRIORITIES": "y,x",
+        "MODEL_ORDER_LIST": [],
+    }
+    response = client.post("/configs/models", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["DEFAULT_MODELS"] == "x,y"
+    assert data["MODEL_FALLBACK_PRIORITIES"] == "y,x"
+
+
+def test_set_models_config_invalid_payload():
+    app = create_app()
+    client = TestClient(app)
+    payload = {
+        "DEFAULT_MODELS": 123,
+        "MODEL_ORDER_LIST": 456,
+    }
+    response = client.post("/configs/models", json=payload)
+    assert response.status_code == 422

--- a/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
@@ -59,11 +59,15 @@
 	const init = async () => {
 		config = await getModelsConfig(localStorage.token);
 
-		if (config?.DEFAULT_MODELS) {
-			defaultModelIds = (config?.DEFAULT_MODELS).split(',').filter((id) => id);
-		} else {
-			defaultModelIds = [];
-		}
+                if (config?.DEFAULT_MODELS) {
+                        if (Array.isArray(config.DEFAULT_MODELS)) {
+                                defaultModelIds = config.DEFAULT_MODELS;
+                        } else {
+                                defaultModelIds = config.DEFAULT_MODELS.split(',').filter((id) => id);
+                        }
+                } else {
+                        defaultModelIds = [];
+                }
 		const modelOrderList = config.MODEL_ORDER_LIST || [];
 		const allModelIds = $models.map((model) => model.id);
 
@@ -83,10 +87,10 @@
 	const submitHandler = async () => {
 		loading = true;
 
-		const res = await setModelsConfig(localStorage.token, {
-			DEFAULT_MODELS: defaultModelIds.join(','),
-			MODEL_ORDER_LIST: modelIds
-		});
+                const res = await setModelsConfig(localStorage.token, {
+                        DEFAULT_MODELS: defaultModelIds,
+                        MODEL_ORDER_LIST: modelIds
+                });
 
 		if (res) {
 			toast.success($i18n.t('Models configuration saved successfully'));


### PR DESCRIPTION
## Summary
- allow lists in models configuration
- send DEFAULT_MODELS as an array from the admin UI
- add tests for valid and invalid /configs/models payloads

## Testing
- `PYTHONPATH=backend:backend/open_webui pytest backend/open_webui/test/apps/webui/routers/test_configs_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68975bb0f714832fb213b39d48c16da7